### PR TITLE
feat(core): Phase 3 - Template Injection for Stateful Mocks (#32)

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -7,7 +7,10 @@
       "Bash(pnpm exec vitest:*)",
       "Bash(git rm:*)",
       "Bash(gh api:*)",
-      "Bash(pnpm test:coverage:*)"
+      "Bash(pnpm test:coverage:*)",
+      "Bash(git checkout:*)",
+      "Bash(git add:*)",
+      "Bash(git commit -m \"$(cat <<''EOF''\nfeat(core): implement template injection for Phase 3\n\nAdd template replacement engine for stateful mock responses:\n\n**Template Replacement Engine:**\n- Created `template-replacement.ts` domain utility\n- Supports `{{state.key}}` pattern detection and replacement\n- Nested path templates: `{{state.user.profile.name}}`\n- Array length templates: `{{state.items.length}}`\n- Missing state keys remain as templates (graceful degradation)\n- Recursive application to objects and arrays\n\n**Integration with ResponseSelector:**\n- Apply templates to response bodies after state capture\n- Templates injected from current state per test ID\n- Works with single responses and sequences\n- Backward compatible (no templates if no state manager)\n\n**Tests:**\n- 11 template replacement unit tests (100% coverage)\n- 7 integration tests in response-selector.test.ts\n- Tests cover: basic injection, nested paths, array length,\n  missing keys, capture+inject, sequences with templates\n\n**Test Results:**\n- 134 tests passing (up from 116)\n- 100% test coverage maintained\n- All edge cases covered (null traversal, non-object traversal)\n\nRelated to #32\n\n🤖 Generated with [Claude Code](https://claude.com/claude-code)\n\nCo-Authored-By: Claude <noreply@anthropic.com>\nEOF\n)\")"
     ],
     "deny": [],
     "ask": []

--- a/packages/core/src/domain/response-selector.ts
+++ b/packages/core/src/domain/response-selector.ts
@@ -7,6 +7,7 @@ import type {
 import type { ResponseSelector, SequenceTracker, StateManager } from "../ports/index.js";
 import { ResponseSelectionError } from "../ports/driven/response-selector.js";
 import { extractFromPath } from "./path-extraction.js";
+import { applyTemplates } from "./template-replacement.js";
 
 /**
  * Options for creating a response selector.
@@ -114,7 +115,14 @@ export const createResponseSelector = (
           captureState(testId, context, bestMatch.mock.captureState, stateManager);
         }
 
-        return { success: true, data: response };
+        // Phase 3: Apply state templates to response if state manager available
+        let finalResponse = response;
+        if (stateManager) {
+          const currentState = stateManager.getAll(testId);
+          finalResponse = applyTemplates(response, currentState) as MockResponse;
+        }
+
+        return { success: true, data: finalResponse };
       }
 
       // No mock matched

--- a/packages/core/src/domain/template-replacement.ts
+++ b/packages/core/src/domain/template-replacement.ts
@@ -1,0 +1,77 @@
+/**
+ * Applies state templates to a value.
+ * Replaces {{state.key}} patterns with actual values from state.
+ *
+ * @param value - Value to apply templates to (string, object, array, or primitive)
+ * @param state - State object containing values for template replacement
+ * @returns Value with templates replaced
+ */
+export const applyTemplates = (value: unknown, state: Record<string, unknown>): unknown => {
+  // Guard: Handle strings (base case)
+  if (typeof value === 'string') {
+    return value.replace(/\{\{state\.([^}]+)\}\}/g, (match, path: string) => {
+      const stateValue = resolveStatePath(state, path);
+
+      // Guard: Missing state keys remain as template
+      if (stateValue === undefined) {
+        return match;
+      }
+
+      // Convert to string for replacement
+      return String(stateValue);
+    });
+  }
+
+  // Guard: Handle arrays recursively
+  if (Array.isArray(value)) {
+    return value.map((item) => applyTemplates(item, state));
+  }
+
+  // Guard: Handle objects recursively
+  if (typeof value === 'object' && value !== null) {
+    const result: Record<string, unknown> = {};
+    for (const [key, val] of Object.entries(value)) {
+      result[key] = applyTemplates(val, state);
+    }
+    return result;
+  }
+
+  // Primitives (number, boolean, null) returned unchanged
+  return value;
+};
+
+/**
+ * Resolves a nested path in state object.
+ * Supports paths like 'user.profile.name' and 'items.length'.
+ *
+ * @param state - State object to traverse
+ * @param path - Path to resolve (e.g., 'user.name' or 'items.length')
+ * @returns Value at path, or undefined if not found
+ */
+const resolveStatePath = (state: Record<string, unknown>, path: string): unknown => {
+  const segments = path.split('.');
+  let current: unknown = state;
+
+  for (const segment of segments) {
+    // Guard: Can't traverse non-objects
+    if (typeof current !== 'object' || current === null) {
+      return undefined;
+    }
+
+    // Handle arrays with .length property
+    if (Array.isArray(current) && segment === 'length') {
+      return current.length;
+    }
+
+    // Traverse object
+    const record = current as Record<string, unknown>;
+    current = record[segment];
+
+    // Guard: Return undefined if property doesn't exist
+    if (current === undefined) {
+      return undefined;
+    }
+  }
+
+  return current;
+};

--- a/packages/core/tests/response-selector.test.ts
+++ b/packages/core/tests/response-selector.test.ts
@@ -1511,3 +1511,275 @@ describe("ResponseSelector - State Capture (Phase 3)", () => {
     expect(stateManager.get("test-1", "userId")).toBe("user-123");
   });
 });
+
+describe("ResponseSelector - Template Injection (Phase 3)", () => {
+  it("should inject state into response body string templates", () => {
+    const stateManager = createInMemoryStateManager();
+    stateManager.set("test-1", "userId", "user-456");
+    stateManager.set("test-1", "itemCount", 3);
+
+    const selector = createResponseSelector({ stateManager });
+
+    const context: HttpRequestContext = {
+      method: "GET",
+      url: "/api/status",
+      headers: {},
+      query: {},
+    };
+
+    const mocks: ReadonlyArray<MockDefinition> = [
+      {
+        method: "GET",
+        url: "/api/status",
+        response: {
+          status: 200,
+          body: {
+            message: "User {{state.userId}} has {{state.itemCount}} items",
+          },
+        },
+      },
+    ];
+
+    const result = selector.selectResponse("test-1", "scenario-1", context, mocks);
+
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.body).toEqual({
+        message: "User user-456 has 3 items",
+      });
+    }
+  });
+
+  it("should inject nested state paths", () => {
+    const stateManager = createInMemoryStateManager();
+    stateManager.set("test-1", "user", {
+      profile: {
+        name: "Alice",
+        email: "alice@example.com",
+      },
+    });
+
+    const selector = createResponseSelector({ stateManager });
+
+    const context: HttpRequestContext = {
+      method: "GET",
+      url: "/api/profile",
+      headers: {},
+      query: {},
+    };
+
+    const mocks: ReadonlyArray<MockDefinition> = [
+      {
+        method: "GET",
+        url: "/api/profile",
+        response: {
+          status: 200,
+          body: {
+            greeting: "Hello, {{state.user.profile.name}}!",
+            contact: "{{state.user.profile.email}}",
+          },
+        },
+      },
+    ];
+
+    const result = selector.selectResponse("test-1", "scenario-1", context, mocks);
+
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.body).toEqual({
+        greeting: "Hello, Alice!",
+        contact: "alice@example.com",
+      });
+    }
+  });
+
+  it("should inject array length", () => {
+    const stateManager = createInMemoryStateManager();
+    stateManager.set("test-1", "cartItems", ["apple", "banana", "orange"]);
+
+    const selector = createResponseSelector({ stateManager });
+
+    const context: HttpRequestContext = {
+      method: "GET",
+      url: "/api/cart",
+      headers: {},
+      query: {},
+    };
+
+    const mocks: ReadonlyArray<MockDefinition> = [
+      {
+        method: "GET",
+        url: "/api/cart",
+        response: {
+          status: 200,
+          body: {
+            message: "You have {{state.cartItems.length}} items in your cart",
+          },
+        },
+      },
+    ];
+
+    const result = selector.selectResponse("test-1", "scenario-1", context, mocks);
+
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.body).toEqual({
+        message: "You have 3 items in your cart",
+      });
+    }
+  });
+
+  it("should leave templates unchanged when state key is missing", () => {
+    const stateManager = createInMemoryStateManager();
+
+    const selector = createResponseSelector({ stateManager });
+
+    const context: HttpRequestContext = {
+      method: "GET",
+      url: "/api/test",
+      headers: {},
+      query: {},
+    };
+
+    const mocks: ReadonlyArray<MockDefinition> = [
+      {
+        method: "GET",
+        url: "/api/test",
+        response: {
+          status: 200,
+          body: {
+            message: "User {{state.userId}} not found",
+          },
+        },
+      },
+    ];
+
+    const result = selector.selectResponse("test-1", "scenario-1", context, mocks);
+
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.body).toEqual({
+        message: "User {{state.userId}} not found",
+      });
+    }
+  });
+
+  it("should capture and inject in same request", () => {
+    const stateManager = createInMemoryStateManager();
+    const selector = createResponseSelector({ stateManager });
+
+    const context: HttpRequestContext = {
+      method: "POST",
+      url: "/api/echo",
+      body: { userName: "Bob", message: "Hello" },
+      headers: {},
+      query: {},
+    };
+
+    const mocks: ReadonlyArray<MockDefinition> = [
+      {
+        method: "POST",
+        url: "/api/echo",
+        captureState: { userName: "body.userName" },
+        response: {
+          status: 200,
+          body: {
+            echo: "Received from {{state.userName}}",
+          },
+        },
+      },
+    ];
+
+    const result = selector.selectResponse("test-1", "scenario-1", context, mocks);
+
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.body).toEqual({
+        echo: "Received from Bob",
+      });
+    }
+  });
+
+  it("should work without state manager (no template replacement)", () => {
+    const selector = createResponseSelector(); // No state manager
+
+    const context: HttpRequestContext = {
+      method: "GET",
+      url: "/api/test",
+      headers: {},
+      query: {},
+    };
+
+    const mocks: ReadonlyArray<MockDefinition> = [
+      {
+        method: "GET",
+        url: "/api/test",
+        response: {
+          status: 200,
+          body: {
+            message: "User {{state.userId}} here",
+          },
+        },
+      },
+    ];
+
+    const result = selector.selectResponse("test-1", "scenario-1", context, mocks);
+
+    expect(result.success).toBe(true);
+    if (result.success) {
+      // Without state manager, templates remain unchanged
+      expect(result.data.body).toEqual({
+        message: "User {{state.userId}} here",
+      });
+    }
+  });
+
+  it("should inject templates in sequence responses", () => {
+    const stateManager = createInMemoryStateManager();
+    stateManager.set("test-1", "jobId", "job-789");
+
+    const sequenceTracker = createInMemorySequenceTracker();
+    const selector = createResponseSelector({ sequenceTracker, stateManager });
+
+    const context: HttpRequestContext = {
+      method: "GET",
+      url: "/api/job/status",
+      headers: {},
+      query: {},
+    };
+
+    const mocks: ReadonlyArray<MockDefinition> = [
+      {
+        method: "GET",
+        url: "/api/job/status",
+        sequence: {
+          responses: [
+            { status: 200, body: { status: "pending", id: "{{state.jobId}}" } },
+            { status: 200, body: { status: "complete", id: "{{state.jobId}}" } },
+          ],
+          repeat: "last",
+        },
+      },
+    ];
+
+    // First call - pending
+    const result1 = selector.selectResponse("test-1", "scenario-1", context, mocks);
+    expect(result1.success).toBe(true);
+    if (result1.success) {
+      expect(result1.data.body).toEqual({
+        status: "pending",
+        id: "job-789",
+      });
+    }
+
+    // Second call - complete
+    const result2 = selector.selectResponse("test-1", "scenario-1", context, mocks);
+    expect(result2.success).toBe(true);
+    if (result2.success) {
+      expect(result2.data.body).toEqual({
+        status: "complete",
+        id: "job-789",
+      });
+    }
+  });
+});

--- a/packages/core/tests/template-replacement.test.ts
+++ b/packages/core/tests/template-replacement.test.ts
@@ -1,0 +1,123 @@
+import { describe, it, expect } from 'vitest';
+import { applyTemplates } from '../src/domain/template-replacement.js';
+
+describe('Template Replacement', () => {
+  it('should replace simple state template in string', () => {
+    const value = 'User ID: {{state.userId}}';
+    const state = { userId: 'user-123' };
+
+    const result = applyTemplates(value, state);
+
+    expect(result).toBe('User ID: user-123');
+  });
+
+  it('should replace multiple templates in one string', () => {
+    const value = 'User {{state.userId}} has {{state.itemCount}} items';
+    const state = { userId: 'user-123', itemCount: 5 };
+
+    const result = applyTemplates(value, state);
+
+    expect(result).toBe('User user-123 has 5 items');
+  });
+
+  it('should leave template unchanged when state key is missing', () => {
+    const value = 'User ID: {{state.userId}}';
+    const state = {};
+
+    const result = applyTemplates(value, state);
+
+    expect(result).toBe('User ID: {{state.userId}}');
+  });
+
+  it('should return non-string values unchanged', () => {
+    const value = 12345;
+    const state = { userId: 'user-123' };
+
+    const result = applyTemplates(value, state);
+
+    expect(result).toBe(12345);
+  });
+
+  it('should replace templates in object values', () => {
+    const value = {
+      message: 'Hello {{state.userName}}',
+      id: '{{state.userId}}',
+    };
+    const state = { userName: 'Alice', userId: 'user-123' };
+
+    const result = applyTemplates(value, state);
+
+    expect(result).toEqual({
+      message: 'Hello Alice',
+      id: 'user-123',
+    });
+  });
+
+  it('should replace templates in array values', () => {
+    const value = ['User: {{state.userId}}', 'Count: {{state.count}}'];
+    const state = { userId: 'user-123', count: 5 };
+
+    const result = applyTemplates(value, state);
+
+    expect(result).toEqual(['User: user-123', 'Count: 5']);
+  });
+
+  it('should support nested path templates', () => {
+    const value = 'User: {{state.user.profile.name}}';
+    const state = {
+      user: {
+        profile: {
+          name: 'Alice',
+        },
+      },
+    };
+
+    const result = applyTemplates(value, state);
+
+    expect(result).toBe('User: Alice');
+  });
+
+  it('should support array length templates', () => {
+    const value = 'You have {{state.items.length}} items';
+    const state = {
+      items: ['apple', 'banana', 'orange'],
+    };
+
+    const result = applyTemplates(value, state);
+
+    expect(result).toBe('You have 3 items');
+  });
+
+  it('should leave template unchanged for missing nested paths', () => {
+    const value = 'User: {{state.user.profile.name}}';
+    const state = {
+      user: {},
+    };
+
+    const result = applyTemplates(value, state);
+
+    expect(result).toBe('User: {{state.user.profile.name}}');
+  });
+
+  it('should return undefined when trying to traverse through non-object', () => {
+    const value = 'Name: {{state.user.profile.name}}';
+    const state = {
+      user: 'Alice', // String, not an object
+    };
+
+    const result = applyTemplates(value, state);
+
+    expect(result).toBe('Name: {{state.user.profile.name}}');
+  });
+
+  it('should return undefined when trying to traverse through null', () => {
+    const value = 'Value: {{state.data.field}}';
+    const state = {
+      data: null,
+    };
+
+    const result = applyTemplates(value, state);
+
+    expect(result).toBe('Value: {{state.data.field}}');
+  });
+});


### PR DESCRIPTION
## Summary

Implements template replacement engine for Phase 3 stateful mocks, enabling dynamic response injection from captured state.

- **Template replacement engine** with `{{state.key}}` pattern detection
- **Nested path support**: `{{state.user.profile.name}}`
- **Array length support**: `{{state.items.length}}`
- **Graceful degradation**: Missing state keys remain as templates
- **Recursive application**: Works on objects and arrays
- **Backward compatible**: No template injection without state manager

## Key Implementation Details

**Template Replacement Engine** (`template-replacement.ts`):
- Pure domain logic with guard clause pattern
- Regex-based pattern detection: `/\{\{state\.([^}]+)\}\}/g`
- Path resolution with dot notation traversal
- Special handling for array `.length` property
- Recursive application to nested structures

**Integration with ResponseSelector**:
- Templates applied after state capture (Phase 1 → 2 → 3 order)
- Uses `stateManager.getAll(testId)` to get current state
- Applied to both single responses and sequence responses
- Only runs when state manager is injected

## Tests

**Unit Tests** (11 tests in `template-replacement.test.ts`):
- ✅ Simple template replacement
- ✅ Multiple templates in one string
- ✅ Missing state keys (templates unchanged)
- ✅ Non-string values (returned unchanged)
- ✅ Object recursion
- ✅ Array recursion
- ✅ Nested path templates
- ✅ Array length templates
- ✅ Null traversal edge case
- ✅ Non-object traversal edge case

**Integration Tests** (7 tests in `response-selector.test.ts`):
- ✅ Basic string template injection
- ✅ Nested state path injection
- ✅ Array length injection
- ✅ Missing state keys (graceful degradation)
- ✅ Capture and inject in same request
- ✅ No state manager (backward compatibility)
- ✅ Template injection in sequences

**Coverage**: 100% (lines, statements, functions, branches)

**Total Tests**: 134 (up from 116, +18 tests)

## Test Plan

- [x] All core package tests pass (134/134)
- [x] 100% test coverage maintained
- [x] Template replacement works with simple keys
- [x] Nested paths work (`state.user.name`)
- [x] Array length works (`state.items.length`)
- [x] Missing keys remain as templates
- [x] Works with single responses
- [x] Works with sequence responses
- [x] Works with state capture in same request
- [x] Backward compatible (no state manager = no injection)
- [x] Edge cases covered (null, non-object traversal)

## Related

- Part of Phase 3: Stateful Mocks
- Follows PR #30 (types & ports) and PR #31 (state capture)
- Next: PR #33 (state reset on scenario switch)
- See: `docs/plans/dynamic-responses.md` (lines 889-894)

🤖 Generated with [Claude Code](https://claude.com/claude-code)