### PR TITLE
feat(tests): Phase 8.5 - Payment/Sequences Demonstration

### DIFF
--- a/apps/nextjs-app-example/app/api/payment/github-job/route.ts
+++ b/apps/nextjs-app-example/app/api/payment/github-job/route.ts
@@ -1,0 +1,46 @@
+/**
+ * GitHub Job Polling API Route - Phase 8.5 Sequences Demo
+ *
+ * Proxies job status requests to json-server (localhost:3001)
+ * where MSW intercepts them.
+ *
+ * Demonstrates repeat: 'last' - sequence progresses through states
+ * (pending → processing → complete) then repeats the last response.
+ */
+
+import { NextResponse } from 'next/server';
+import { getScenaristHeaders } from '@scenarist/nextjs-adapter/app';
+import { scenarist } from '../../../../lib/scenarist';
+
+type JobStatusResponse = {
+  readonly jobId: string;
+  readonly status: string;
+  readonly progress: number;
+};
+
+export async function GET(request: Request) {
+  try {
+    // Proxy to json-server (MSW will intercept on server-side)
+    const response = await fetch('http://localhost:3001/github/jobs/123', {
+      method: 'GET',
+      headers: {
+        'Content-Type': 'application/json',
+        ...getScenaristHeaders(request, scenarist), // ✅ Pass test ID to MSW
+      },
+    });
+
+    if (!response.ok) {
+      throw new Error(`External API error: ${response.status}`);
+    }
+
+    const data: JobStatusResponse = await response.json();
+    return NextResponse.json(data);
+  } catch (error) {
+    return NextResponse.json(
+      {
+        error: error instanceof Error ? error.message : 'Failed to check job status',
+      },
+      { status: 500 }
+    );
+  }
+}

--- a/apps/nextjs-app-example/app/api/payment/submit/route.ts
+++ b/apps/nextjs-app-example/app/api/payment/submit/route.ts
@@ -1,0 +1,64 @@
+/**
+ * Payment Submit API Route - Phase 8.5 Sequences Demo
+ *
+ * Proxies payment requests to json-server (localhost:3001)
+ * where MSW intercepts them.
+ *
+ * Demonstrates repeat: 'none' - sequence allows 3 attempts,
+ * then exhausts and falls through to rate limit error (429).
+ */
+
+import { NextResponse } from 'next/server';
+import { getScenaristHeaders } from '@scenarist/nextjs-adapter/app';
+import { scenarist } from '../../../../lib/scenarist';
+
+type PaymentRequest = {
+  readonly amount: number;
+};
+
+type PaymentResponse = {
+  readonly id: string;
+  readonly status: string;
+};
+
+type PaymentErrorResponse = {
+  readonly error: {
+    readonly message: string;
+  };
+};
+
+export async function POST(request: Request) {
+  try {
+    const body: PaymentRequest = await request.json();
+
+    // Proxy to json-server (MSW will intercept on server-side)
+    const response = await fetch('http://localhost:3001/payments', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        ...getScenaristHeaders(request, scenarist), // ✅ Pass test ID to MSW
+      },
+      body: JSON.stringify(body),
+    });
+
+    const data = await response.json();
+
+    // Return error responses with appropriate status codes
+    if (!response.ok) {
+      return NextResponse.json(data as PaymentErrorResponse, {
+        status: response.status,
+      });
+    }
+
+    return NextResponse.json(data as PaymentResponse);
+  } catch (error) {
+    return NextResponse.json(
+      {
+        error: {
+          message: error instanceof Error ? error.message : 'Failed to submit payment',
+        },
+      },
+      { status: 500 }
+    );
+  }
+}

--- a/apps/nextjs-app-example/app/api/payment/weather/route.ts
+++ b/apps/nextjs-app-example/app/api/payment/weather/route.ts
@@ -1,0 +1,46 @@
+/**
+ * Weather API Route - Phase 8.5 Sequences Demo
+ *
+ * Proxies weather requests to json-server (localhost:3001)
+ * where MSW intercepts them.
+ *
+ * Demonstrates repeat: 'cycle' - sequence cycles through states
+ * (Sunny → Cloudy → Rainy → back to Sunny) infinitely.
+ */
+
+import { NextResponse } from 'next/server';
+import { getScenaristHeaders } from '@scenarist/nextjs-adapter/app';
+import { scenarist } from '../../../../lib/scenarist';
+
+type WeatherResponse = {
+  readonly city: string;
+  readonly conditions: string;
+  readonly temp: number;
+};
+
+export async function GET(request: Request) {
+  try {
+    // Proxy to json-server (MSW will intercept on server-side)
+    const response = await fetch('http://localhost:3001/weather/London', {
+      method: 'GET',
+      headers: {
+        'Content-Type': 'application/json',
+        ...getScenaristHeaders(request, scenarist), // ✅ Pass test ID to MSW
+      },
+    });
+
+    if (!response.ok) {
+      throw new Error(`External API error: ${response.status}`);
+    }
+
+    const data: WeatherResponse = await response.json();
+    return NextResponse.json(data);
+  } catch (error) {
+    return NextResponse.json(
+      {
+        error: error instanceof Error ? error.message : 'Failed to get weather',
+      },
+      { status: 500 }
+    );
+  }
+}

--- a/apps/nextjs-app-example/app/payment/page.tsx
+++ b/apps/nextjs-app-example/app/payment/page.tsx
@@ -1,0 +1,242 @@
+/**
+ * Payment/Sequences Page - Phase 8.5 Response Sequences Demo
+ *
+ * Demonstrates Scenarist's response sequences feature (Phase 2):
+ * 1. GitHub Polling (repeat: 'last') - Polls until complete, stays at final response
+ * 2. Weather Cycle (repeat: 'cycle') - Cycles through states infinitely
+ * 3. Payment Limited (repeat: 'none') - Falls through after exhaustion (rate limiting)
+ *
+ * Client Component - Requires state and effects for API calls.
+ */
+
+'use client';
+
+import { useState } from 'react';
+import Link from 'next/link';
+
+type JobStatus = {
+  readonly jobId: string;
+  readonly status: string;
+  readonly progress: number;
+};
+
+type WeatherStatus = {
+  readonly city: string;
+  readonly conditions: string;
+  readonly temp: number;
+};
+
+type PaymentResult = {
+  readonly id: string;
+  readonly status: string;
+};
+
+type PaymentError = {
+  readonly error: {
+    readonly message: string;
+  };
+};
+
+export default function PaymentPage() {
+  const [jobStatus, setJobStatus] = useState<JobStatus | null>(null);
+  const [weatherStatus, setWeatherStatus] = useState<WeatherStatus | null>(null);
+  const [paymentResult, setPaymentResult] = useState<PaymentResult | null>(null);
+  const [paymentError, setPaymentError] = useState<PaymentError | null>(null);
+  const [isCheckingJob, setIsCheckingJob] = useState(false);
+  const [isCheckingWeather, setIsCheckingWeather] = useState(false);
+  const [isSubmittingPayment, setIsSubmittingPayment] = useState(false);
+
+  const handleCheckJobStatus = async () => {
+    setIsCheckingJob(true);
+    try {
+      const response = await fetch('/api/payment/github-job', {
+        method: 'GET',
+      });
+      const data: JobStatus = await response.json();
+      setJobStatus(data);
+    } finally {
+      setIsCheckingJob(false);
+    }
+  };
+
+  const handleGetWeather = async () => {
+    setIsCheckingWeather(true);
+    try {
+      const response = await fetch('/api/payment/weather', {
+        method: 'GET',
+      });
+      const data: WeatherStatus = await response.json();
+      setWeatherStatus(data);
+    } finally {
+      setIsCheckingWeather(false);
+    }
+  };
+
+  const handleSubmitPayment = async () => {
+    setIsSubmittingPayment(true);
+    setPaymentError(null);
+    try {
+      const response = await fetch('/api/payment/submit', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ amount: 100 }),
+      });
+
+      if (!response.ok) {
+        const errorData: PaymentError = await response.json();
+        setPaymentError(errorData);
+        setPaymentResult(null);
+      } else {
+        const data: PaymentResult = await response.json();
+        setPaymentResult(data);
+        setPaymentError(null);
+      }
+    } finally {
+      setIsSubmittingPayment(false);
+    }
+  };
+
+  return (
+    <main className="min-h-screen bg-gray-50 p-8">
+      <div className="max-w-4xl mx-auto">
+        <h1 className="text-4xl font-bold text-gray-900 mb-4">Response Sequences Demo</h1>
+
+        <nav aria-label="Main navigation" className="mb-8">
+          <Link href="/" className="text-blue-600 hover:text-blue-700 underline">
+            Back to Products
+          </Link>
+        </nav>
+
+        <div className="grid grid-cols-1 gap-8">
+          {/* GitHub Job Polling (repeat: 'last') */}
+          <section className="bg-white p-6 rounded-lg shadow">
+            <h2 className="text-2xl font-semibold mb-4">1. GitHub Job Polling (repeat: 'last')</h2>
+            <p className="text-gray-600 mb-6">
+              Demonstrates polling pattern. Sequence progresses through pending → processing → complete,
+              then repeats the last response indefinitely.
+            </p>
+
+            <button
+              onClick={handleCheckJobStatus}
+              disabled={isCheckingJob}
+              className="w-full bg-blue-600 hover:bg-blue-700 disabled:bg-gray-400 text-white font-medium py-2 px-4 rounded transition-colors mb-6"
+            >
+              {isCheckingJob ? 'Checking...' : 'Check Job Status'}
+            </button>
+
+            {jobStatus && (
+              <div
+                role="status"
+                aria-live="polite"
+                className="bg-blue-50 border border-blue-200 p-4 rounded-lg"
+              >
+                <p className="mb-2">
+                  <span className="font-semibold">Job ID:</span> {jobStatus.jobId}
+                </p>
+                <p className="mb-2">
+                  <span className="font-semibold">Status:</span>{' '}
+                  <span className={jobStatus.status === 'complete' ? 'text-green-600' : 'text-blue-600'}>
+                    {jobStatus.status}
+                  </span>
+                </p>
+                <div className="mb-2">
+                  <span className="font-semibold">Progress:</span> {jobStatus.progress}%
+                </div>
+                <div
+                  role="progressbar"
+                  aria-valuenow={jobStatus.progress}
+                  aria-valuemin={0}
+                  aria-valuemax={100}
+                  className="w-full bg-gray-200 rounded-full h-2.5 mt-2"
+                >
+                  <div
+                    className="bg-blue-600 h-2.5 rounded-full transition-all duration-300"
+                    style={{ width: `${jobStatus.progress}%` }}
+                  />
+                </div>
+              </div>
+            )}
+          </section>
+
+          {/* Weather Cycle (repeat: 'cycle') */}
+          <section className="bg-white p-6 rounded-lg shadow">
+            <h2 className="text-2xl font-semibold mb-4">2. Weather Cycle (repeat: 'cycle')</h2>
+            <p className="text-gray-600 mb-6">
+              Demonstrates cycling pattern. Sequence cycles through Sunny → Cloudy → Rainy,
+              then loops back to the start infinitely.
+            </p>
+
+            <button
+              onClick={handleGetWeather}
+              disabled={isCheckingWeather}
+              className="w-full bg-green-600 hover:bg-green-700 disabled:bg-gray-400 text-white font-medium py-2 px-4 rounded transition-colors mb-6"
+            >
+              {isCheckingWeather ? 'Checking...' : 'Get Weather'}
+            </button>
+
+            {weatherStatus && (
+              <div
+                role="status"
+                aria-live="polite"
+                className="bg-green-50 border border-green-200 p-4 rounded-lg"
+              >
+                <p className="mb-2">
+                  <span className="font-semibold">City:</span> {weatherStatus.city}
+                </p>
+                <p className="mb-2">
+                  <span className="font-semibold">Conditions:</span>{' '}
+                  <span className="text-green-700">{weatherStatus.conditions}</span>
+                </p>
+                <p>
+                  <span className="font-semibold">Temperature:</span> {weatherStatus.temp}°C
+                </p>
+              </div>
+            )}
+          </section>
+
+          {/* Payment Limited (repeat: 'none') */}
+          <section className="bg-white p-6 rounded-lg shadow">
+            <h2 className="text-2xl font-semibold mb-4">3. Payment Limited (repeat: 'none')</h2>
+            <p className="text-gray-600 mb-6">
+              Demonstrates rate limiting. Allows 3 payment attempts, then falls through to
+              rate limit error. Sequence exhausts and never repeats.
+            </p>
+
+            <button
+              onClick={handleSubmitPayment}
+              disabled={isSubmittingPayment}
+              className="w-full bg-purple-600 hover:bg-purple-700 disabled:bg-gray-400 text-white font-medium py-2 px-4 rounded transition-colors mb-6"
+            >
+              {isSubmittingPayment ? 'Submitting...' : 'Submit Payment'}
+            </button>
+
+            {paymentResult && (
+              <div
+                role="status"
+                aria-live="polite"
+                className="bg-purple-50 border border-purple-200 p-4 rounded-lg"
+              >
+                <p className="mb-2">
+                  <span className="font-semibold">Payment ID:</span> {paymentResult.id}
+                </p>
+                <p>
+                  <span className="font-semibold">Status:</span>{' '}
+                  <span className={paymentResult.status === 'succeeded' ? 'text-green-600' : 'text-purple-600'}>
+                    {paymentResult.status}
+                  </span>
+                </p>
+              </div>
+            )}
+
+            {paymentError && (
+              <div role="alert" className="bg-red-50 border border-red-200 p-4 rounded-lg">
+                <p className="text-red-700 font-semibold mb-2">Payment Failed</p>
+                <p className="text-red-600">{paymentError.error.message}</p>
+              </div>
+            )}
+          </section>
+        </div>
+      </div>
+    </main>
+  );
+}

--- a/apps/nextjs-app-example/tests/playwright/sequences.spec.ts
+++ b/apps/nextjs-app-example/tests/playwright/sequences.spec.ts
@@ -1,0 +1,124 @@
+/**
+ * Sequences Tests - Phase 8.5 Response Sequences
+ *
+ * Purpose: Demonstrate response sequences (Phase 2 core feature)
+ *
+ * DEMONSTRATES: Best practices for testing sequence patterns
+ * - GitHub polling (repeat: 'last') - stays at final response
+ * - Weather cycle (repeat: 'cycle') - loops back to start
+ * - Payment limited (repeat: 'none') - falls through after exhaustion
+ * - Accessible UI patterns (getByRole, aria-live, progressbar)
+ */
+
+import { test, expect } from './fixtures';
+
+test.describe('Sequences - Response Sequences', () => {
+  test('should demonstrate GitHub polling sequence with visual progression (repeat: "last")', async ({
+    page,
+    switchScenario,
+  }) => {
+    // Switch to GitHub polling scenario
+    await switchScenario(page, 'githubPolling');
+    await page.goto('/payment');
+
+    // Verify page loaded
+    await expect(page.getByRole('heading', { name: 'Response Sequences Demo' })).toBeVisible();
+
+    // First click - pending (0%)
+    await page.getByRole('button', { name: 'Check Job Status' }).click();
+    const jobStatus = page.getByRole('status').first();
+    await expect(jobStatus).toContainText('Job ID: 123');
+    await expect(jobStatus).toContainText('Status: pending');
+    await expect(jobStatus).toContainText('Progress: 0%');
+
+    // Verify progress bar
+    const progressBar = page.getByRole('progressbar');
+    await expect(progressBar).toHaveAttribute('aria-valuenow', '0');
+
+    // Second click - processing (50%)
+    await page.getByRole('button', { name: 'Check Job Status' }).click();
+    await expect(jobStatus).toContainText('Status: processing');
+    await expect(jobStatus).toContainText('Progress: 50%');
+    await expect(progressBar).toHaveAttribute('aria-valuenow', '50');
+
+    // Third click - complete (100%)
+    await page.getByRole('button', { name: 'Check Job Status' }).click();
+    await expect(jobStatus).toContainText('Status: complete');
+    await expect(jobStatus).toContainText('Progress: 100%');
+    await expect(progressBar).toHaveAttribute('aria-valuenow', '100');
+
+    // Fourth click - Demonstrates repeat: 'last' (stays at complete)
+    await page.getByRole('button', { name: 'Check Job Status' }).click();
+    await expect(jobStatus).toContainText('Status: complete');
+    await expect(jobStatus).toContainText('Progress: 100%');
+    await expect(progressBar).toHaveAttribute('aria-valuenow', '100');
+  });
+
+  test('should demonstrate weather cycle sequence with visual updates (repeat: "cycle")', async ({
+    page,
+    switchScenario,
+  }) => {
+    // Switch to weather cycle scenario
+    await switchScenario(page, 'weatherCycle');
+    await page.goto('/payment');
+
+    const weatherButton = page.getByRole('button', { name: 'Get Weather' });
+
+    // First click - Sunny
+    await weatherButton.click();
+    const weatherStatus = page.getByRole('status').filter({ hasText: 'City: London' });
+    await expect(weatherStatus).toContainText('City: London');
+    await expect(weatherStatus).toContainText('Conditions: Sunny');
+    await expect(weatherStatus).toContainText('Temperature: 20°C');
+
+    // Second click - Cloudy
+    await weatherButton.click();
+    await expect(weatherStatus).toContainText('Conditions: Cloudy');
+    await expect(weatherStatus).toContainText('Temperature: 18°C');
+
+    // Third click - Rainy
+    await weatherButton.click();
+    await expect(weatherStatus).toContainText('Conditions: Rainy');
+    await expect(weatherStatus).toContainText('Temperature: 15°C');
+
+    // Fourth click - Demonstrates repeat: 'cycle' (back to Sunny)
+    await weatherButton.click();
+    await expect(weatherStatus).toContainText('Conditions: Sunny');
+    await expect(weatherStatus).toContainText('Temperature: 20°C');
+  });
+
+  test('should demonstrate payment sequence with exhaustion and error (repeat: "none")', async ({
+    page,
+    switchScenario,
+  }) => {
+    // Switch to payment limited scenario
+    await switchScenario(page, 'paymentLimited');
+    await page.goto('/payment');
+
+    const paymentButton = page.getByRole('button', { name: 'Submit Payment' });
+
+    // First payment - Pending (ch_1)
+    await paymentButton.click();
+    const paymentStatus = page.getByRole('status').filter({ hasText: 'Payment ID' });
+    await expect(paymentStatus).toContainText('Payment ID: ch_1');
+    await expect(paymentStatus).toContainText('Status: pending');
+
+    // Second payment - Pending (ch_2)
+    await paymentButton.click();
+    await expect(paymentStatus).toContainText('Payment ID: ch_2');
+    await expect(paymentStatus).toContainText('Status: pending');
+
+    // Third payment - Succeeded (ch_3)
+    await paymentButton.click();
+    await expect(paymentStatus).toContainText('Payment ID: ch_3');
+    await expect(paymentStatus).toContainText('Status: succeeded');
+
+    // Fourth payment - Demonstrates repeat: 'none' (rate limit error)
+    await paymentButton.click();
+    const errorAlert = page.getByRole('alert').filter({ hasText: 'Payment Failed' });
+    await expect(errorAlert).toContainText('Rate limit exceeded');
+
+    // Verify status is no longer visible (replaced by error)
+    await expect(paymentStatus).not.toBeVisible();
+  });
+});


### PR DESCRIPTION
## Summary

Implements Phase 8.5 of the Next.js App Router example, demonstrating **response sequences** (Phase 2 core feature) with all three repeat modes.

## Features

### Payment Page (`/payment`)
- **3 sequence demonstrations** with visual progression
- GitHub polling (repeat: 'last') - polls until complete, then stays at final response
- Weather cycle (repeat: 'cycle') - cycles through states infinitely
- Payment limited (repeat: 'none') - falls through after exhaustion (rate limiting)
- Tailwind-styled with accessible UI patterns

### API Routes
Created 3 proxy routes that forward Scenarist headers for test ID isolation:
- `app/api/payment/github-job/route.ts` - GitHub job polling
- `app/api/payment/weather/route.ts` - Weather requests
- `app/api/payment/submit/route.ts` - Payment submissions

### Tests
**File:** `tests/playwright/sequences.spec.ts`

**3 comprehensive tests** (all passing):
1. **GitHub Polling** - Verifies pending → processing → complete → stays complete
2. **Weather Cycle** - Verifies Sunny → Cloudy → Rainy → back to Sunny  
3. **Payment Limited** - Verifies 3 attempts succeed, 4th gets rate limited (429)

Uses semantic selectors (`getByRole` with filters) for accessible testing.

## Test Results

```
✅ 3 tests passing (2.2s execution)
```

All three repeat modes verified working correctly:
- `repeat: 'last'` - Repeats final response indefinitely
- `repeat: 'cycle'` - Loops back to first response
- `repeat: 'none'` - Falls through after exhaustion

## Files Changed

- `app/payment/page.tsx` - Payment sequences demonstration page (214 lines)
- `app/api/payment/github-job/route.ts` - GitHub polling proxy (47 lines)
- `app/api/payment/weather/route.ts` - Weather proxy (45 lines)
- `app/api/payment/submit/route.ts` - Payment submission proxy (63 lines)
- `tests/playwright/sequences.spec.ts` - Sequence tests (125 lines)

**Total:** 5 files, 522 lines added

## Implementation Notes

### Selector Strategy
Initially used positional selectors (`.nth(1)`, `.nth(2)`) which failed because status elements only render conditionally after API calls. Fixed by using **filter-based selectors**:

```typescript
// ✅ Correct - Filter by unique content
const weatherStatus = page.getByRole('status').filter({ hasText: 'City: London' });
const paymentStatus = page.getByRole('status').filter({ hasText: 'Payment ID' });
```

This ensures tests select the correct status element regardless of which sections have rendered.

### Accessibility
All UI sections use proper semantic HTML:
- `role="status"` with `aria-live="polite"` for dynamic updates
- `role="progressbar"` with `aria-valuenow` for progress indication
- `role="alert"` for error messages
- Semantic button and heading structure

## Related

- Phase 8.5 implementation plan in `docs/plans/nextjs-pages-and-playwright-helpers.md`
- Sequence scenarios already exist in `lib/scenarios.ts` (shared with Pages Router)
- Follows Pages Router implementation pattern from `apps/nextjs-pages-example`