### PR TITLE
docs: clarify library vs example apps in PR review guidelines

### DIFF
--- a/.claude/review-prompt.md
+++ b/.claude/review-prompt.md
@@ -2,7 +2,35 @@
 
 This file contains specific rules and guidelines for reviewing code in the Scenarist repository. Use these rules when reviewing pull requests.
 
-## Critical Architecture Rules
+## CRITICAL: Scope of Architecture Rules
+
+**These architecture rules apply to LIBRARY CODE ONLY (`packages/*`), NOT to example apps (`apps/*`).**
+
+### Library Code (`packages/*`)
+- **Strict hexagonal architecture** - Zero framework coupling in core
+- **All architecture rules below apply**
+- This is the published npm package - must be pristine
+- Examples: `packages/core`, `packages/express-adapter`, `packages/nextjs-adapter`
+
+### Example Apps (`apps/*`)
+- **Realistic demonstration applications** showing how to USE Scenarist
+- **NOT library code** - these are end-user applications
+- **Intentionally use non-hexagonal patterns** to show real-world integration:
+  - Direct HTTP calls (fetch, axios) - showing how real apps work
+  - Framework coupling (Express routes, Next.js API routes) - the whole point
+  - Imperative code patterns - realistic application code
+  - Direct json-server calls for production tests - proving tree-shaking works
+- **DO NOT flag hexagonal violations** in these apps
+- **DO review for**:
+  - Test quality and coverage (E2E tests demonstrating Scenarist works)
+  - Correct Scenarist usage (proper scenario definitions, state management)
+  - Production parity (same journey works mocked and in production)
+  - Clear demonstration of Scenarist features
+- Examples: `apps/express-example`, `apps/nextjs-app-router-example`, `apps/nextjs-pages-router-example`
+
+**If you're reviewing changes to `apps/*`, skip hexagonal architecture checks and focus on test quality and realistic integration patterns.**
+
+## Critical Architecture Rules (packages/* ONLY)
 
 ### 1. Hexagonal Architecture (Ports & Adapters)
 

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -47,7 +47,16 @@ jobs:
             Also reference `CLAUDE.md` for general development guidance.
             Review testing approach against `docs/testing-guidelines.md` and `docs/adrs/0003-testing-strategy.md`.
 
-            **Key Architecture Rules to Enforce:**
+            **CRITICAL: Library vs Example Apps**
+            - **Library Code (`packages/*`)**: Strict hexagonal architecture - enforce ALL rules below
+            - **Example Apps (`apps/*`)**: Demonstration/testing applications showing real-world Scenarist usage
+              - These are NOT library code - they're realistic example applications
+              - They intentionally use non-hexagonal patterns (direct HTTP calls, framework coupling, imperative code)
+              - DO NOT flag hexagonal violations in `apps/*` - they're meant to show practical integration
+              - Focus reviews on: test quality, correct Scenarist usage, production parity demonstration
+              - Example apps exist to prove Scenarist works in real frameworks with real patterns
+
+            **Key Architecture Rules to Enforce (packages/* ONLY):**
             1. Hexagonal Architecture - Core has zero framework dependencies
             2. Serializable Scenarios - No functions in scenario definitions
             3. Dependency Injection - All ports injected, never created internally
@@ -60,13 +69,14 @@ jobs:
             **Your Task:**
             1. Read the PR changes using `gh pr diff ${{ github.event.pull_request.number }}`
             2. Review against the rules in `.claude/review-prompt.md`
-            3. Check for violations of hexagonal architecture, serialization, dependency injection
-            4. Verify test coverage follows four-layer strategy (see `docs/testing-guidelines.md`)
-            5. Ensure tests verify behavior, not implementation details
-            6. Check that tests are at the correct layer (core vs adapter vs integration)
-            7. Leave a constructive review comment using `gh pr comment ${{ github.event.pull_request.number }} --body "..."`
+            3. For `packages/*` changes: Check for violations of hexagonal architecture, serialization, dependency injection
+            4. For `apps/*` changes: Focus on test quality, correct Scenarist usage, realistic integration patterns
+            5. Verify test coverage follows appropriate strategy (four-layer for library, E2E for examples)
+            6. Ensure tests verify behavior, not implementation details
+            7. Check that tests are at the correct layer (core vs adapter vs integration vs E2E)
+            8. Leave a constructive review comment using `gh pr comment ${{ github.event.pull_request.number }} --body "..."`
 
-            Be specific, reference relevant documentation, and provide examples. Focus on architecture violations first, then code quality.
+            Be specific, reference relevant documentation, and provide examples. For library code (`packages/*`), focus on architecture violations first, then code quality. For example apps (`apps/*`), focus on demonstrating realistic usage patterns and test coverage.
 
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://docs.claude.com/en/docs/claude-code/cli-reference for available options


### PR DESCRIPTION
## Summary

Updates PR review guidelines to explicitly distinguish between library code (`packages/*`) and example apps (`apps/*`), preventing false positive architecture violation flags.

## Changes

- **`.github/workflows/claude-code-review.yml`**: Added CRITICAL section explaining example apps are demonstration applications showing realistic integration patterns, not library code
- **`.claude/review-prompt.md`**: Added prominent section at top of file clarifying scope of architecture rules

## Why This Matters

The Claude Code Review workflow was flagging hexagonal architecture violations in example apps, but these "violations" are intentional:

- Example apps demonstrate **realistic integration** of Scenarist into real frameworks
- They intentionally use non-hexagonal patterns (direct HTTP calls, framework coupling, imperative code)
- This shows users how to integrate Scenarist into their own apps
- Production E2E tests prove tree-shaking works (Scenarist code removed from production bundles)

## Context

This change is needed before PR #126 can be properly reviewed. The workflow file must exist on the main branch before it can review PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>