### PR TITLE
docs: add parallel agent workflow documentation for v1.0 release

### DIFF
--- a/docs/release/agent-prompt-template.md
+++ b/docs/release/agent-prompt-template.md
@@ -1,0 +1,364 @@
+# Agent Prompt Template
+
+Copy and customize the prompt below for each workstream agent.
+
+---
+
+## Workstream A (Changesets)
+
+```
+You are working on the Scenarist v1.0 release. You have been assigned to **Workstream A: Changesets Setup**.
+
+## Your Assignment
+
+**Worktree**: You are operating in a dedicated git worktree for this workstream.
+**Branch**: `workstream-a`
+**Issues**: #142, #143, #144 (in that order)
+
+## Before You Start
+
+1. Read the workflow rules: `docs/release/parallel-agent-workflow.md`
+2. Read the full release plan: `~/.claude/plans/melodic-wibbling-porcupine.md`
+
+## Your Tickets (in order)
+
+1. **#142 - A1: Install and initialize Changesets** (blocker)
+   - Install @changesets/cli and @changesets/changelog-github
+   - Run `pnpm changeset init`
+   - Verify .changeset/ directory created
+
+2. **#143 - A2: Configure Changesets for fixed versioning** (blocker)
+   - Depends on #142
+   - Configure .changeset/config.json per the plan
+   - Fixed versioning for 3 public packages (NOT core - it's internal)
+   - Ignore list for all internal/example packages
+
+3. **#144 - A3: Create initial changeset for v1.0.0**
+   - Depends on #143
+   - Run `pnpm changeset` and select all 3 public packages
+   - Choose "major" bump type
+
+## Rules
+
+1. **Work tickets in order** - #142 → #143 → #144
+2. **Small incremental commits** - Each commit must pass tests/types/lint
+3. **Create a plan before starting each ticket** - Document in your PR
+4. **Commit message format**: `chore(changesets): <description>`
+5. **Final commit for each ticket**: Include `closes #<issue-number>`
+6. **Create a PR for each ticket** - Don't batch multiple tickets
+
+## Cross-Workstream Note
+
+Workstream D (GitHub Actions) depends on your #143 completing before they can start #154. Prioritize accordingly.
+
+Start by reading the workflow document, then begin with ticket #142.
+```
+
+---
+
+## Workstream B (Package Metadata)
+
+```
+You are working on the Scenarist v1.0 release. You have been assigned to **Workstream B: Package Metadata**.
+
+## Your Assignment
+
+**Worktree**: You are operating in a dedicated git worktree for this workstream.
+**Branch**: `workstream-b`
+**Issues**: #147, #148, #149 (can be done in any order - all marked `parallel`)
+
+## Before You Start
+
+1. Read the workflow rules: `docs/release/parallel-agent-workflow.md`
+2. Read the full release plan: `~/.claude/plans/melodic-wibbling-porcupine.md`
+
+## Your Tickets (any order)
+
+1. **#147 - B1: Add publishConfig to @scenarist/express-adapter** (parallel)
+   - Add `publishConfig` with `access: public`
+   - Add `engines` field with `node: >=18.0.0`
+   - Verify version is `0.0.0`
+
+2. **#148 - B2: Add publishConfig to @scenarist/nextjs-adapter** (parallel)
+   - Add `publishConfig` with `access: public`
+   - Add `engines` field with `node: >=18.0.0`
+   - Verify version is `0.0.0`
+
+3. **#149 - B3: Add publishConfig to @scenarist/playwright-helpers** (parallel)
+   - Add `publishConfig` with `access: public`
+   - Add `engines` field with `node: >=18.0.0`
+   - Reset version from `0.1.0` to `0.0.0`
+
+## Rules
+
+1. **These tickets can be done in any order** - All marked `parallel`
+2. **Small incremental commits** - Each commit must pass tests/types/lint
+3. **Create a plan before starting each ticket** - Document in your PR
+4. **Commit message format**: `chore(metadata): <description>`
+5. **Final commit for each ticket**: Include `closes #<issue-number>`
+6. **Create a PR for each ticket** - Don't batch multiple tickets
+
+## Cross-Workstream Note
+
+Workstream E's ticket #159 (dry-run publish) depends on all your tickets completing. Work efficiently.
+
+Start by reading the workflow document, then begin with any ticket.
+```
+
+---
+
+## Workstream C (Documentation)
+
+```
+You are working on the Scenarist v1.0 release. You have been assigned to **Workstream C: Documentation**.
+
+## Your Assignment
+
+**Worktree**: You are operating in a dedicated git worktree for this workstream.
+**Branch**: `workstream-c`
+**Issues**: #150, #151, #152, #153 (can be done in any order - all marked `parallel`)
+
+## Before You Start
+
+1. Read the workflow rules: `docs/release/parallel-agent-workflow.md`
+2. Read the full release plan: `~/.claude/plans/melodic-wibbling-porcupine.md`
+
+## Your Tickets (any order)
+
+1. **#150 - C1: Create CONTRIBUTING.md** (parallel)
+   - Document development setup
+   - Document TDD requirements
+   - Document changeset workflow
+   - Document PR guidelines
+
+2. **#151 - C2: Update root README with installation instructions** (parallel, blocker)
+   - Add npm/pnpm/yarn install commands
+   - Add npm badges for all packages
+   - Update documentation link to https://scenarist.io
+
+3. **#152 - C3: Update @scenarist/core README** (parallel)
+   - Note: Core is becoming internal - clarify this in README
+   - Add badge and install instructions
+   - Link to https://scenarist.io
+
+4. **#153 - C4: Update adapter and helper READMEs** (parallel)
+   - Update express-adapter README with badge + install (npm/pnpm/yarn)
+   - Update nextjs-adapter README with badge + install (npm/pnpm/yarn)
+   - Update playwright-helpers README with badge + install (npm/pnpm/yarn)
+
+## Rules
+
+1. **These tickets can be done in any order** - All marked `parallel`
+2. **Small incremental commits** - Each commit must pass tests/types/lint
+3. **Create a plan before starting each ticket** - Document in your PR
+4. **Commit message format**: `docs: <description>`
+5. **Final commit for each ticket**: Include `closes #<issue-number>`
+6. **Create a PR for each ticket** - Don't batch multiple tickets
+
+## Important Context
+
+- Documentation site is https://scenarist.io (NOT scenarist.dev)
+- Core package is becoming internal - users import from adapters, not core
+- Always show all 3 package managers: npm, pnpm, yarn
+- Only 3 packages will be published: express-adapter, nextjs-adapter, playwright-helpers
+
+Start by reading the workflow document, then begin with any ticket.
+```
+
+---
+
+## Workstream D (GitHub Actions)
+
+```
+You are working on the Scenarist v1.0 release. You have been assigned to **Workstream D: GitHub Actions**.
+
+## Your Assignment
+
+**Worktree**: You are operating in a dedicated git worktree for this workstream.
+**Branch**: `workstream-d`
+**Issues**: #154, #155, #156
+
+## Before You Start
+
+1. Read the workflow rules: `docs/release/parallel-agent-workflow.md`
+2. Read the full release plan: `~/.claude/plans/melodic-wibbling-porcupine.md`
+
+## IMPORTANT: Cross-Workstream Dependency
+
+**#154 (D1) depends on #143 (A2) from Workstream A completing first.**
+
+Before starting #154, verify A2 is merged:
+```bash
+gh issue view 143 --json state
+```
+
+If not merged, wait or check back periodically.
+
+## Your Tickets (in order)
+
+1. **#154 - D1: Create release workflow** (blocker)
+   - WAIT for #143 to merge first
+   - Create `.github/workflows/release.yml`
+   - Configure Changesets action
+   - Set up npm publishing and GitHub Release creation
+
+2. **#155 - D2: Create pre-release workflow** (blocker)
+   - Depends on #154
+   - Create `.github/workflows/pre-release.yml`
+   - Support beta and RC branches
+   - Publish with appropriate npm tags (@beta, @rc)
+
+3. **#156 - D3: Add changeset check to CI**
+   - Can be done in parallel with D1/D2 (only depends on #142)
+   - Add job to `.github/workflows/ci.yml`
+   - Warn (not fail) when PRs have no changeset
+
+## Rules
+
+1. **Work tickets in dependency order** - Wait for dependencies before starting
+2. **Small incremental commits** - Each commit must pass tests/types/lint
+3. **Create a plan before starting each ticket** - Document in your PR
+4. **Commit message format**: `ci: <description>`
+5. **Final commit for each ticket**: Include `closes #<issue-number>`
+6. **Create a PR for each ticket** - Don't batch multiple tickets
+
+## Workflow YAML Reference
+
+The full release plan contains the complete YAML for both workflows. Reference it when implementing.
+
+Start by reading the workflow document, then check if #143 is merged before beginning.
+```
+
+---
+
+## Workstream E (Repository Preparation)
+
+```
+You are working on the Scenarist v1.0 release. You have been assigned to **Workstream E: Repository Preparation**.
+
+## Your Assignment
+
+**Worktree**: You are operating in a dedicated git worktree for this workstream.
+**Branch**: `workstream-e`
+**Issues**: #157, #158, #159
+
+## Before You Start
+
+1. Read the workflow rules: `docs/release/parallel-agent-workflow.md`
+2. Read the full release plan: `~/.claude/plans/melodic-wibbling-porcupine.md`
+
+## Your Tickets
+
+1. **#157 - E1: Configure NPM_TOKEN secret** (blocker, parallel)
+   - Generate npm automation token at npmjs.com
+   - Add NPM_TOKEN to GitHub repository secrets
+   - NOTE: This requires manual action by the repo owner - document the steps clearly
+
+2. **#158 - E2: Create initial git tag** (parallel)
+   - `git tag v0.0.0`
+   - `git push origin v0.0.0`
+   - This establishes baseline for changelog generation
+
+3. **#159 - E3: Test dry-run npm publish**
+   - **WAIT for all B* issues (#147, #148, #149) to merge first**
+   - Run dry-run publish for all 3 public packages
+   - Verify no errors about missing fields
+
+## Rules
+
+1. **#157 and #158 can be done in parallel**
+2. **#159 must wait for Workstream B to complete**
+3. **Small incremental commits** - Each commit must pass tests/types/lint
+4. **Create a plan before starting each ticket** - Document in your PR
+5. **Commit message format**: `chore(release): <description>`
+6. **Final commit for each ticket**: Include `closes #<issue-number>`
+
+## Cross-Workstream Dependency Check
+
+Before starting #159:
+```bash
+gh issue view 147 --json state
+gh issue view 148 --json state
+gh issue view 149 --json state
+```
+
+All must show `"state": "CLOSED"`.
+
+Start by reading the workflow document, then begin with #157 or #158.
+```
+
+---
+
+## Workstream F (Move Core to Internal)
+
+```
+You are working on the Scenarist v1.0 release. You have been assigned to **Workstream F: Move Core to Internal**.
+
+## Your Assignment
+
+**Worktree**: You are operating in a dedicated git worktree for this workstream.
+**Branch**: `workstream-f`
+**Issues**: #145, #146 (in that order)
+
+## Before You Start
+
+1. Read the workflow rules: `docs/release/parallel-agent-workflow.md`
+2. Read the full release plan: `~/.claude/plans/melodic-wibbling-porcupine.md`
+
+## Context
+
+Investigation revealed that example apps already import all types from adapters, not from @scenarist/core directly. The adapters re-export everything users need. Therefore, core should be an internal package (not published to npm).
+
+## Your Tickets (in order)
+
+1. **#145 - F1: Move @scenarist/core to internal** (blocker)
+   - Move `packages/core` → `internal/core`
+   - Update pnpm-workspace.yaml if needed
+   - Update all import paths in adapters
+   - Update turbo.json if any core-specific tasks
+   - Mark package.json as `"private": true`
+   - Run full test suite to verify no breakage
+
+2. **#146 - F2: Update documentation to import from adapters** (blocker)
+   - Depends on #145
+   - Update `apps/docs/src/content/docs/` files
+   - Change `from '@scenarist/core'` → `from '@scenarist/express-adapter'` (or nextjs-adapter)
+   - Update root README.md if it mentions core imports
+   - Verify all code examples still work
+
+## Rules
+
+1. **Work tickets in order** - #145 → #146
+2. **Small incremental commits** - Each commit must pass tests/types/lint
+3. **Create a plan before starting each ticket** - Document in your PR
+4. **Commit message format**: `refactor(core): <description>` for F1, `docs: <description>` for F2
+5. **Final commit for each ticket**: Include `closes #<issue-number>`
+6. **Create a PR for each ticket** - Don't batch multiple tickets
+
+## Critical: Test Everything
+
+Moving core is high-risk. After each change:
+```bash
+pnpm install
+pnpm build
+pnpm test
+pnpm check-types
+```
+
+All must pass before committing.
+
+Start by reading the workflow document, then begin with ticket #145.
+```
+
+---
+
+## Quick Copy Reference
+
+| Workstream | Copy from section |
+|------------|-------------------|
+| A | "Workstream A (Changesets)" |
+| B | "Workstream B (Package Metadata)" |
+| C | "Workstream C (Documentation)" |
+| D | "Workstream D (GitHub Actions)" |
+| E | "Workstream E (Repository Preparation)" |
+| F | "Workstream F (Move Core to Internal)" |

--- a/docs/release/parallel-agent-workflow.md
+++ b/docs/release/parallel-agent-workflow.md
@@ -1,0 +1,298 @@
+# Parallel Agent Workflow Guide
+
+This document defines the rules and procedures for running multiple Claude agents in parallel using git worktrees to complete the Scenarist v1.0 release.
+
+## Overview
+
+Each workstream is assigned to a dedicated git worktree and Claude agent. Agents work independently on their assigned tickets, following strict rules for ticket ordering, incremental commits, and coordination.
+
+## Worktree Setup
+
+### Creating Worktrees
+
+```bash
+# From main repository
+cd /Users/paulhammond/personal/scenarist
+
+# Create worktrees for each workstream
+git worktree add ../scenarist-workstream-a release-plan -b workstream-a
+git worktree add ../scenarist-workstream-b release-plan -b workstream-b
+git worktree add ../scenarist-workstream-c release-plan -b workstream-c
+git worktree add ../scenarist-workstream-d release-plan -b workstream-d
+git worktree add ../scenarist-workstream-e release-plan -b workstream-e
+git worktree add ../scenarist-workstream-f release-plan -b workstream-f
+```
+
+### Worktree Assignment
+
+| Worktree | Branch | Workstream | Issues |
+|----------|--------|------------|--------|
+| `scenarist-workstream-a` | `workstream-a` | Changesets Setup | #142, #143, #144 |
+| `scenarist-workstream-b` | `workstream-b` | Package Metadata | #147, #148, #149 |
+| `scenarist-workstream-c` | `workstream-c` | Documentation | #150, #151, #152, #153 |
+| `scenarist-workstream-d` | `workstream-d` | GitHub Actions | #154, #155, #156 |
+| `scenarist-workstream-e` | `workstream-e` | Repository Prep | #157, #158, #159 |
+| `scenarist-workstream-f` | `workstream-f` | Move Core | #145, #146 |
+
+---
+
+## Agent Rules
+
+### Rule 1: One Agent Per Worktree
+
+- Each agent operates exclusively within its assigned worktree
+- Agents must NOT modify files outside their worktree
+- Agents must NOT push to branches other than their assigned branch
+
+### Rule 2: Ticket Pickup Order
+
+Agents must pick up tickets in dependency order within their workstream.
+
+#### Determining Ticket Order
+
+1. **Read the ticket's "Depends On" section** - If present, those tickets must be completed first
+2. **Within a workstream, follow numerical order** - A1 → A2 → A3, B1 → B2 → B3, etc.
+3. **Tickets marked `parallel` can be done in any order** within their workstream
+4. **Tickets marked `blocker` must be prioritized**
+
+#### Workstream Ticket Order
+
+| Workstream | Order | Rationale |
+|------------|-------|-----------|
+| **A (Changesets)** | #142 → #143 → #144 | Sequential dependency chain |
+| **B (Metadata)** | #147, #148, #149 (any order) | All marked `parallel` |
+| **C (Docs)** | #150, #151, #152, #153 (any order) | All marked `parallel` |
+| **D (Actions)** | #154 → #155 → #156 | D2 depends on D1; D3 can parallel D1/D2 |
+| **E (Repo Prep)** | #157, #158 (parallel) → #159 | E3 depends on B* completing |
+| **F (Move Core)** | #145 → #146 | F2 depends on F1 |
+
+#### Cross-Workstream Dependencies
+
+Some tickets depend on other workstreams completing:
+
+| Ticket | Depends On | Action |
+|--------|------------|--------|
+| #154 (D1) | #143 (A2) | D agent must wait for A to merge A2 |
+| #159 (E3) | All B* issues | E agent must wait for B to complete |
+| #160 (I1) | All A*, B*, D*, E1, E2, F* | Integration phase - after all workstreams |
+| #161 (I2) | #160 (I1) | Final step |
+
+**How to check if a dependency is met:**
+```bash
+# Check if a ticket's PR has been merged to main
+gh pr list --state merged --search "closes #143"
+
+# Or check if the branch contains the changes
+git log main --oneline --grep="closes #143"
+```
+
+### Rule 3: Work in Small Increments
+
+Each ticket should be completed through multiple small commits, not one large commit.
+
+#### Commit Strategy
+
+1. **Plan phase**: Read ticket, create mental model of work needed
+2. **Incremental commits**: One logical change per commit
+3. **Each commit must**:
+   - Pass all tests (`pnpm test`)
+   - Pass type checking (`pnpm check-types`)
+   - Pass linting (`pnpm lint`)
+   - Be independently revertable
+
+#### Commit Message Format
+
+```
+<type>(<scope>): <description>
+
+closes #<issue-number> (only on final commit for ticket)
+```
+
+**Types**: `feat`, `fix`, `docs`, `chore`, `refactor`, `test`
+
+**Examples**:
+```bash
+# Incremental commits
+git commit -m "chore(changesets): install @changesets/cli"
+git commit -m "chore(changesets): install @changesets/changelog-github"
+git commit -m "chore(changesets): initialize with pnpm changeset init"
+
+# Final commit closes the issue
+git commit -m "chore(changesets): add config.json for fixed versioning
+
+closes #143"
+```
+
+### Rule 4: Create a Plan Before Starting Each Ticket
+
+Before writing any code for a ticket, the agent must:
+
+1. **Read the ticket fully** - Understand all tasks and acceptance criteria
+2. **Identify files to modify** - List all files that will be created/changed
+3. **Break into commits** - Plan the sequence of small commits
+4. **Check dependencies** - Verify any dependent tickets are complete
+5. **Document the plan** - Create a brief plan in the PR description
+
+#### Plan Template
+
+```markdown
+## Plan for #<issue-number>
+
+### Files to Modify
+- [ ] `path/to/file1.ts`
+- [ ] `path/to/file2.json`
+
+### Commit Sequence
+1. `chore(scope): first change`
+2. `chore(scope): second change`
+3. `chore(scope): final change - closes #<issue>`
+
+### Dependencies Verified
+- [x] #<dep-issue> merged to main
+
+### Acceptance Criteria Check
+- [ ] Criterion 1
+- [ ] Criterion 2
+```
+
+### Rule 5: PR Creation and Merging
+
+#### Creating PRs
+
+After completing all commits for a ticket:
+
+```bash
+# Push branch
+git push -u origin workstream-a
+
+# Create PR
+gh pr create \
+  --title "A1: Install and initialize Changesets" \
+  --body "Closes #142
+
+## Summary
+- Installed @changesets/cli and @changesets/changelog-github
+- Initialized changesets with \`pnpm changeset init\`
+- Verified .changeset/ directory created
+
+## Plan
+[Include plan from Rule 4]
+" \
+  --base main
+```
+
+#### PR Requirements
+
+- Title matches ticket title
+- Body includes "Closes #XXX" to auto-close issue
+- All CI checks pass
+- Plan included in description
+
+#### Merging Strategy
+
+1. **Self-merge allowed** for non-blocking tickets within your workstream
+2. **Request review** for `blocker` tickets
+3. **Squash merge** preferred to keep history clean
+4. **After merge**: Pull main into your worktree branch
+
+```bash
+# After your PR is merged
+git checkout workstream-a
+git fetch origin
+git rebase origin/main
+```
+
+---
+
+## Coordination Protocol
+
+### Status Updates
+
+Agents should update ticket status as they work:
+
+```bash
+# When starting a ticket
+gh issue edit 142 --add-label "in-progress"
+
+# When PR is ready
+gh issue edit 142 --remove-label "in-progress" --add-label "review"
+
+# Issue auto-closes when PR merges with "closes #142"
+```
+
+### Handling Cross-Workstream Dependencies
+
+When your ticket depends on another workstream:
+
+1. **Check dependency status**:
+   ```bash
+   gh issue view <dep-issue-number> --json state,labels
+   ```
+
+2. **If not complete**: Work on other tickets in your workstream, or wait
+
+3. **If complete**:
+   ```bash
+   # Pull the changes into your branch
+   git fetch origin
+   git rebase origin/main
+   ```
+
+### Conflict Resolution
+
+If you encounter merge conflicts:
+
+1. **Never force push** to shared branches
+2. **Rebase on main** regularly to minimize conflicts
+3. **If conflict in shared file**: Coordinate with the other agent's workstream
+4. **Document conflicts** in PR comments
+
+---
+
+## Quick Reference: Ticket Dependencies Graph
+
+```
+                    #142 (A1)
+                       │
+                       ▼
+                    #143 (A2)
+                       │
+          ┌────────────┼────────────┐
+          │            │            │
+          ▼            ▼            ▼
+       #144 (A3)   #154 (D1)   #156 (D3)
+                       │
+                       ▼
+                   #155 (D2)
+
+#145 (F1) ──► #146 (F2)
+
+#147 (B1) ─┐
+#148 (B2) ─┼──► #159 (E3)
+#149 (B3) ─┘
+
+#157 (E1) ─┬──► #160 (I1) ──► #161 (I2)
+#158 (E2) ─┘
+
+#150, #151, #152, #153 (C1-C4): All independent
+```
+
+---
+
+## Checklist: Before Starting Work
+
+- [ ] Worktree created and on correct branch
+- [ ] Latest main pulled into branch
+- [ ] Ticket dependencies verified as complete
+- [ ] Plan created for ticket
+- [ ] `pnpm install` run in worktree
+- [ ] All tests passing before starting
+
+## Checklist: Before Creating PR
+
+- [ ] All commits follow message format
+- [ ] All tests pass (`pnpm test`)
+- [ ] Type checking passes (`pnpm check-types`)
+- [ ] Linting passes (`pnpm lint`)
+- [ ] Acceptance criteria from ticket verified
+- [ ] PR description includes plan and "Closes #XXX"


### PR DESCRIPTION
## Summary

Adds documentation to support running multiple Claude agents in parallel using git worktrees for the v1.0 release.

### Files Added

- `docs/release/parallel-agent-workflow.md` - Rules and procedures for parallel agent coordination
- `docs/release/agent-prompt-template.md` - Ready-to-use prompts for each workstream agent

### What's Documented

- **Worktree setup** - Commands to create 6 worktrees (one per workstream)
- **5 core agent rules**:
  1. One agent per worktree
  2. Ticket pickup order (dependencies → numerical)
  3. Small incremental commits
  4. Plan before starting each ticket
  5. PR creation and merging
- **Ticket dependency graph** - Visual representation of cross-workstream dependencies
- **Customized prompts** for each workstream (A-F)

### Related

- GitHub Project: https://github.com/users/citypaul/projects/7
- Issues: #142-#161

🤖 Generated with [Claude Code](https://claude.com/claude-code)