### PR TITLE
fix(core): mark package as private to prevent npm publish

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@scenarist/core",
   "version": "0.0.0",
+  "private": true,
   "description": "Hexagonal architecture core for scenario-based testing with MSW",
   "author": "Paul Hammond (citypaul) <paul@packsoftware.co.uk>",
   "license": "MIT",


### PR DESCRIPTION
## Summary

Addresses PR #164 review feedback: Core package was not marked as `private: true`, which would cause it to be published to npm during releases.

## Changes

- Added `"private": true` to `packages/core/package.json`

## Why This is Needed

**The Problem:**
- Public packages (express-adapter, nextjs-adapter, playwright-helpers) depend on Core
- Changesets validation prevents ignoring packages that other packages depend on
- Therefore, Core cannot be in the `ignore` list
- Without `private: true`, Core would be versioned AND published

**The Solution:**
- Mark Core as `private: true`
- Core is still versioned by Changesets (unavoidable due to dependency relationship)
- Core is NOT published to npm (due to `private: true`)
- Adapters re-export all types users need

## Verification

```bash
$ pnpm changeset status
🦋  info Packages to be bumped at major:
🦋  - @scenarist/express-adapter
🦋  - @scenarist/nextjs-adapter
🦋  - @scenarist/playwright-helpers
```

Core is NOT in the list of packages to be published.

## Related

- Addresses review feedback on PR #164
- Aligns with release plan: Core is **INTERNAL** (not published)

🤖 Generated with [Claude Code](https://claude.com/claude-code)