### PR TITLE
docs: update documentation to import from adapters instead of core

### DIFF
--- a/README.md
+++ b/README.md
@@ -457,7 +457,7 @@ Scenarios are defined as declarative patterns (not MSW handlers with imperative 
 
 ```typescript
 // scenarios/default.ts
-import type { ScenaristScenario } from "@scenarist/core";
+import type { ScenaristScenario } from "@scenarist/express-adapter";
 
 export const defaultScenario: ScenaristScenario = {
   id: "default",
@@ -493,7 +493,7 @@ export const defaultScenario: ScenaristScenario = {
 
 ```typescript
 // scenarios/error-state.ts
-import type { ScenaristScenario } from "@scenarist/core";
+import type { ScenaristScenario } from "@scenarist/express-adapter";
 
 export const errorState: ScenaristScenario = {
   id: "error-state",
@@ -526,7 +526,7 @@ export const errorState: ScenaristScenario = {
 // server.ts
 import express from "express";
 import { createScenarist } from "@scenarist/express-adapter";
-import type { ScenaristScenarios } from "@scenarist/core";
+import type { ScenaristScenarios } from "@scenarist/express-adapter";
 import { defaultScenario, errorState } from "./scenarios";
 
 const app = express();

--- a/apps/docs/CONTRIBUTING.md
+++ b/apps/docs/CONTRIBUTING.md
@@ -44,7 +44,7 @@ Next.js
 ```markdown
 ✅ CORRECT:
 ```bash
-npm install @scenarist/core
+npm install @scenarist/express-adapter
 \```
 
 ```typescript
@@ -53,7 +53,7 @@ export const scenarios = { ... };
 
 ❌ WRONG:
 \```
-npm install @scenarist/core
+npm install @scenarist/express-adapter
 \```
 
 \```

--- a/apps/docs/src/content/docs/concepts/architecture.mdx
+++ b/apps/docs/src/content/docs/concepts/architecture.mdx
@@ -25,7 +25,7 @@ This architecture ensures your code runs in production-like conditions (real mid
 
 ## The Hexagon: Framework-Agnostic Core
 
-The core package (`@scenarist/core`) contains all domain logic with **zero dependencies** on any web framework:
+The internal core package contains all domain logic with **zero dependencies** on any web framework. Users interact with this through adapters - the core is not installed directly:
 
 ```mermaid
 graph TD
@@ -419,16 +419,17 @@ export const createScenarioManager = ({
 
 ### Default Implementations
 
-The core provides default in-memory implementations:
+The core provides default in-memory implementations. Note: This is internal implementation detail - users interact through adapters, not directly with core:
 
 ```typescript
+// Internal implementation (adapters use this, users don't import directly)
 import {
   createScenarioManager,
   InMemoryScenarioRegistry,
   InMemoryScenarioStore,
   InMemoryStateManager,
   InMemorySequenceTracker,
-} from '@scenarist/core';
+} from '@scenarist/core';  // Internal package
 
 const registry = new InMemoryScenarioRegistry();
 const store = new InMemoryScenarioStore();

--- a/apps/docs/src/content/docs/frameworks/express/getting-started.mdx
+++ b/apps/docs/src/content/docs/frameworks/express/getting-started.mdx
@@ -8,7 +8,7 @@ Test your Express APIs with runtime scenario switching. Zero boilerplate setup u
 ## Installation
 
 ```bash
-npm install @scenarist/core @scenarist/express-adapter
+npm install @scenarist/express-adapter
 npm install -D @playwright/test @scenarist/playwright-helpers
 ```
 

--- a/apps/docs/src/content/docs/frameworks/nextjs-app-router/getting-started.mdx
+++ b/apps/docs/src/content/docs/frameworks/nextjs-app-router/getting-started.mdx
@@ -10,7 +10,7 @@ Test your Next.js App Router application with Server Components, Route Handlers,
 ## Installation
 
 ```bash
-npm install @scenarist/core @scenarist/nextjs-adapter
+npm install @scenarist/nextjs-adapter
 npm install -D @playwright/test @scenarist/playwright-helpers
 ```
 

--- a/apps/docs/src/content/docs/frameworks/nextjs-pages-router/getting-started.mdx
+++ b/apps/docs/src/content/docs/frameworks/nextjs-pages-router/getting-started.mdx
@@ -10,7 +10,7 @@ Test your Next.js Pages Router application with API routes, getServerSideProps, 
 ## Installation
 
 ```bash
-npm install @scenarist/core @scenarist/nextjs-adapter
+npm install @scenarist/nextjs-adapter
 npm install -D @playwright/test @scenarist/playwright-helpers
 ```
 

--- a/apps/docs/src/content/docs/introduction/capabilities.mdx
+++ b/apps/docs/src/content/docs/introduction/capabilities.mdx
@@ -18,7 +18,7 @@ Return different responses based on request content. Multiple mocks can exist fo
 Match on request body, headers, or query parameters:
 
 ```typescript
-import type { ScenaristMock } from '@scenarist/core';
+import type { ScenaristMock } from '@scenarist/express-adapter';
 
 const mock: ScenaristMock = {
   method: 'POST',
@@ -43,7 +43,7 @@ When multiple mocks match the same URL, Scenarist uses specificity scoring:
 **Example:**
 
 ```typescript
-import type { ScenaristScenario } from '@scenarist/core';
+import type { ScenaristScenario } from '@scenarist/express-adapter';
 
 const premiumScenario: ScenaristScenario = {
   id: 'premium',
@@ -90,7 +90,7 @@ const premiumScenario: ScenaristScenario = {
 Body matching is **partial** - only the specified fields must match:
 
 ```typescript
-import type { ScenaristMock } from '@scenarist/core';
+import type { ScenaristMock } from '@scenarist/express-adapter';
 
 const mock: ScenaristMock = {
   method: 'POST',
@@ -112,7 +112,7 @@ const mock: ScenaristMock = {
 Header and query parameter matching is **exact** for specified keys:
 
 ```typescript
-import type { ScenaristMock } from '@scenarist/core';
+import type { ScenaristMock } from '@scenarist/express-adapter';
 
 const mock: ScenaristMock = {
   method: 'GET',
@@ -132,7 +132,7 @@ You can combine multiple match criteria across body, headers, and query paramete
 **Example with mixed strategies:**
 
 ```typescript
-import type { ScenaristMock } from '@scenarist/core';
+import type { ScenaristMock } from '@scenarist/express-adapter';
 
 const mock: ScenaristMock = {
   method: 'POST',
@@ -179,7 +179,7 @@ const mock: ScenaristMock = {
 Since match criteria use AND logic, implement OR logic by creating multiple mocks:
 
 ```typescript
-import type { ScenaristScenario } from '@scenarist/core';
+import type { ScenaristScenario } from '@scenarist/express-adapter';
 
 const scenario: ScenaristScenario = {
   id: 'premium-or-vip',
@@ -273,7 +273,7 @@ See [Issue #99](https://github.com/citypaul/scenarist/issues/99) for details.
 
 **Headers:**
 ```typescript
-import type { ScenaristMock } from '@scenarist/core';
+import type { ScenaristMock } from '@scenarist/express-adapter';
 
 const mock: ScenaristMock = {
   method: 'GET',
@@ -294,7 +294,7 @@ const mock: ScenaristMock = {
 
 **Query Parameters:**
 ```typescript
-import type { ScenaristMock } from '@scenarist/core';
+import type { ScenaristMock } from '@scenarist/express-adapter';
 
 const mock: ScenaristMock = {
   method: 'GET',
@@ -315,7 +315,7 @@ const mock: ScenaristMock = {
 
 **Body Fields:**
 ```typescript
-import type { ScenaristMock } from '@scenarist/core';
+import type { ScenaristMock } from '@scenarist/express-adapter';
 
 const mock: ScenaristMock = {
   method: 'POST',
@@ -339,7 +339,7 @@ const mock: ScenaristMock = {
 **Marketing Campaigns:**
 
 ```typescript
-import type { ScenaristMock } from '@scenarist/core';
+import type { ScenaristMock } from '@scenarist/express-adapter';
 
 const mock: ScenaristMock = {
   method: 'GET',
@@ -367,7 +367,7 @@ const mock: ScenaristMock = {
 **Referer Patterns:**
 
 ```typescript
-import type { ScenaristMock } from '@scenarist/core';
+import type { ScenaristMock } from '@scenarist/express-adapter';
 
 const mock: ScenaristMock = {
   method: 'POST',
@@ -391,7 +391,7 @@ const mock: ScenaristMock = {
 **User Agent Detection:**
 
 ```typescript
-import type { ScenaristMock } from '@scenarist/core';
+import type { ScenaristMock } from '@scenarist/express-adapter';
 
 const mock: ScenaristMock = {
   method: 'GET',
@@ -465,7 +465,7 @@ Regex patterns work identically in headers, query parameters, and body fields:
 
 **Headers:**
 ```typescript
-import type { ScenaristMock } from '@scenarist/core';
+import type { ScenaristMock } from '@scenarist/express-adapter';
 
 const mock: ScenaristMock = {
   method: 'GET',
@@ -483,7 +483,7 @@ const mock: ScenaristMock = {
 
 **Query Parameters:**
 ```typescript
-import type { ScenaristMock } from '@scenarist/core';
+import type { ScenaristMock } from '@scenarist/express-adapter';
 
 const mock: ScenaristMock = {
   method: 'GET',
@@ -506,7 +506,7 @@ const mock: ScenaristMock = {
 
 **Body Fields:**
 ```typescript
-import type { ScenaristMock } from '@scenarist/core';
+import type { ScenaristMock } from '@scenarist/express-adapter';
 
 const mock: ScenaristMock = {
   method: 'POST',
@@ -549,7 +549,7 @@ Simulate multi-step processes like polling, where each request advances through 
 ### Basic Sequence
 
 ```typescript
-import type { ScenaristMock } from '@scenarist/core';
+import type { ScenaristMock } from '@scenarist/express-adapter';
 
 const mock: ScenaristMock = {
   method: 'GET',
@@ -609,7 +609,7 @@ sequence: {
 **`repeat: 'none'`** - After sequence exhausts, fall through to next mock
 
 ```typescript
-import type { ScenaristScenario } from '@scenarist/core';
+import type { ScenaristScenario } from '@scenarist/express-adapter';
 
 const scenario: ScenaristScenario = {
   id: 'payment-sequence',
@@ -642,7 +642,7 @@ const scenario: ScenaristScenario = {
 Sequences can be combined with match criteria:
 
 ```typescript
-import type { ScenaristMock } from '@scenarist/core';
+import type { ScenaristMock } from '@scenarist/express-adapter';
 
 const mock: ScenaristMock = {
   method: 'GET',
@@ -670,7 +670,7 @@ Capture data from requests and inject it into subsequent responses, enabling sta
 ### Basic State Capture and Injection
 
 ```typescript
-import type { ScenaristScenario } from '@scenarist/core';
+import type { ScenaristScenario } from '@scenarist/express-adapter';
 
 const scenario: ScenaristScenario = {
   id: 'cart-state',
@@ -710,7 +710,7 @@ const scenario: ScenaristScenario = {
 Use `stateKey[]` to append values to an array:
 
 ```typescript
-import type { ScenaristMock } from '@scenarist/core';
+import type { ScenaristMock } from '@scenarist/express-adapter';
 
 const mock: ScenaristMock = {
   method: 'POST',
@@ -740,7 +740,7 @@ const mock: ScenaristMock = {
 Capture deeply nested values using dot notation:
 
 ```typescript
-import type { ScenaristMock } from '@scenarist/core';
+import type { ScenaristMock } from '@scenarist/express-adapter';
 
 const mock: ScenaristMock = {
   method: 'POST',
@@ -769,7 +769,7 @@ const mock: ScenaristMock = {
 Use `{{state.key}}` syntax to inject captured state into responses:
 
 ```typescript
-import type { ScenaristMock } from '@scenarist/core';
+import type { ScenaristMock } from '@scenarist/express-adapter';
 
 const mock: ScenaristMock = {
   method: 'GET',
@@ -824,7 +824,7 @@ test('cart workflow', async ({ page, switchScenario }) => {
 The power comes from combining request matching, sequences, and state together:
 
 ```typescript
-import type { ScenaristScenario } from '@scenarist/core';
+import type { ScenaristScenario } from '@scenarist/express-adapter';
 
 const scenario: ScenaristScenario = {
   id: 'premium-onboarding',

--- a/apps/docs/src/content/docs/introduction/default-mocks.mdx
+++ b/apps/docs/src/content/docs/introduction/default-mocks.mdx
@@ -10,7 +10,7 @@ Scenarist uses a **default-first** approach: define baseline mocks in a 'default
 Every scenarios object **must have a 'default' key** (enforced via schema validation):
 
 ```typescript
-import type { ScenaristScenarios } from '@scenarist/core';
+import type { ScenaristScenarios } from '@scenarist/express-adapter';
 
 export const scenarios = {
   default: defaultScenario,    // ✅ Required

--- a/apps/docs/src/content/docs/introduction/quick-start.mdx
+++ b/apps/docs/src/content/docs/introduction/quick-start.mdx
@@ -24,8 +24,8 @@ By the end of this guide, you'll have:
 ## Installation
 
 ```bash
-# Install Scenarist core + adapter for your framework
-npm install @scenarist/core @scenarist/[your-framework]-adapter
+# Install Scenarist adapter for your framework
+npm install @scenarist/[your-framework]-adapter
 
 # Install Playwright helpers
 npm install -D @playwright/test @scenarist/playwright-helpers
@@ -37,7 +37,8 @@ Create a file to define your mock scenarios:
 
 ```typescript
 // scenarios.ts
-import type { ScenaristScenario, ScenaristScenarios } from '@scenarist/core';
+import type { ScenaristScenario, ScenaristScenarios } from '@scenarist/express-adapter';
+// Note: Types are re-exported from all adapters. Use your framework's adapter.
 
 const successScenario: ScenaristScenario = {
   id: 'success',


### PR DESCRIPTION
## Summary

Since `@scenarist/core` is now an internal package (PR #169), documentation must show imports from adapters instead. Adapters re-export all necessary types for user convenience.

**Changes:**
- Remove `@scenarist/core` from install commands (users only need adapters)
- Update all type imports to use `@scenarist/express-adapter`
- Add notes that types are re-exported from all adapters
- Update architecture.mdx to clarify core is internal implementation
- Update root README.md examples

## Files Changed (9)

- `README.md` - Update type imports
- `apps/docs/CONTRIBUTING.md` - Update install examples  
- `apps/docs/src/content/docs/concepts/architecture.mdx` - Clarify core is internal
- `apps/docs/src/content/docs/frameworks/express/getting-started.mdx` - Remove core from install
- `apps/docs/src/content/docs/frameworks/nextjs-app-router/getting-started.mdx` - Remove core from install
- `apps/docs/src/content/docs/frameworks/nextjs-pages-router/getting-started.mdx` - Remove core from install
- `apps/docs/src/content/docs/introduction/capabilities.mdx` - Update type imports
- `apps/docs/src/content/docs/introduction/default-mocks.mdx` - Update type imports
- `apps/docs/src/content/docs/introduction/quick-start.mdx` - Update type imports

## Test plan

- [ ] Verify no documentation references `@scenarist/core` imports (except internal implementation notes)
- [ ] All examples show adapter imports
- [ ] Docs build successfully

Closes #146

🤖 Generated with [Claude Code](https://claude.com/claude-code)