### PR TITLE
fix(release): add Playwright install for docs build

### DIFF
--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -38,6 +38,9 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
+      - name: Install Playwright for docs build
+        run: pnpm --filter=@scenarist/docs exec playwright install --with-deps chromium
+
       - name: Build packages
         run: pnpm build
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,6 +37,9 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
+      - name: Install Playwright for docs build
+        run: pnpm --filter=@scenarist/docs exec playwright install --with-deps chromium
+
       - name: Build packages
         run: pnpm build
 


### PR DESCRIPTION
## Summary

The release workflow failed because the docs site requires Playwright to render Mermaid diagrams during build.

**Error:**
```
browserType.launch: Executable doesn't exist at /home/runner/.cache/ms-playwright/chromium_headless_shell-1194/chrome-linux/headless_shell
```

## Fix

Added Playwright install step to both release workflows (same as CI and deploy-docs workflows):
```yaml
- name: Install Playwright for docs build
  run: pnpm --filter=@scenarist/docs exec playwright install --with-deps chromium
```

## Related

- Failed run: https://github.com/citypaul/scenarist/actions/runs/19715844374

🤖 Generated with [Claude Code](https://claude.com/claude-code)