### PR TITLE
fix(release): correct typecheck command name

### DIFF
--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -45,7 +45,7 @@ jobs:
         run: pnpm build
 
       - name: Type check
-        run: pnpm check-types
+        run: pnpm typecheck
 
       - name: Run tests
         run: pnpm test

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,7 +44,7 @@ jobs:
         run: pnpm build
 
       - name: Type check
-        run: pnpm check-types
+        run: pnpm typecheck
 
       - name: Run tests
         run: pnpm test


### PR DESCRIPTION
## Summary

The release workflow failed because the typecheck command was incorrect.

**Error:**
```
ERR_PNPM_RECURSIVE_EXEC_FIRST_FAIL  Command "check-types" not found
```

## Fix

Changed `pnpm check-types` → `pnpm typecheck` to match the actual script in package.json.

🤖 Generated with [Claude Code](https://claude.com/claude-code)