### PR TITLE
refactor(release): remove redundant tests from release workflow

### DIFF
--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -38,17 +38,28 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
-      - name: Install Playwright for docs build
-        run: pnpm --filter=@scenarist/docs exec playwright install --with-deps chromium
+      - name: Install Playwright browsers
+        run: |
+          # For docs (mermaid rendering) and example apps (E2E tests)
+          pnpm --filter=@scenarist/docs exec playwright install --with-deps chromium
+          pnpm --filter=@scenarist/nextjs-pages-router-example exec playwright install chromium
 
       - name: Build packages
         run: pnpm build
 
+      # Note: Tests are required here because CI only runs on main branch.
+      # For release/* branches, this is the only validation before publish.
       - name: Type check
         run: pnpm typecheck
 
       - name: Run tests
         run: pnpm test
+
+      - name: Run production build tests
+        run: |
+          pnpm --filter=@scenarist/express-example test:production
+          pnpm --filter=@scenarist/nextjs-app-router-example test:production
+          pnpm --filter=@scenarist/nextjs-pages-router-example test:production
 
       - name: Determine pre-release tag
         id: tag

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,7 +1,10 @@
 name: Release
 
 on:
-  push:
+  workflow_run:
+    workflows: ["CI"]
+    types:
+      - completed
     branches:
       - main
 
@@ -18,6 +21,8 @@ jobs:
   release:
     name: Release
     runs-on: ubuntu-latest
+    # Only run if CI succeeded
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -42,12 +47,6 @@ jobs:
 
       - name: Build packages
         run: pnpm build
-
-      - name: Type check
-        run: pnpm typecheck
-
-      - name: Run tests
-        run: pnpm test
 
       - name: Upgrade npm for OIDC trusted publishing
         run: |


### PR DESCRIPTION
## Summary

The release workflow now **depends on CI success** before running. The pre-release workflow runs comprehensive tests including production builds.

## Changes

### release.yml (main branch)
- Changed from `push` trigger to `workflow_run` trigger
- Waits for CI to complete, only proceeds if CI succeeded
- No duplicate tests (CI already validated)

```yaml
on:
  workflow_run:
    workflows: ["CI"]
    types: [completed]
    branches: [main]

jobs:
  release:
    if: ${{ github.event.workflow_run.conclusion == 'success' }}
```

### pre-release.yml (release/beta, release/rc)
- Kept all tests (CI doesn't cover these branches)
- Added Playwright browser install for example apps
- Added production build tests to verify tree-shaking

**Tests run:**
- `pnpm typecheck` - Type checking
- `pnpm test` - Unit tests + E2E tests (Playwright)
- `test:production` - Production build tests for all example apps

🤖 Generated with [Claude Code](https://claude.com/claude-code)