### PR TITLE
fix(docs): correct social preview image path

### DIFF
--- a/apps/docs/src/layouts/LandingLayout.astro
+++ b/apps/docs/src/layouts/LandingLayout.astro
@@ -11,7 +11,7 @@ interface Props {
 const {
   title,
   description,
-  image = '/og-image.png',
+  image = 'https://scenarist.io/social-preview.png',
   canonicalUrl = Astro.url.href,
 } = Astro.props;
 


### PR DESCRIPTION
## Summary

Fix 404 error for social preview image on landing page.

### Changes
- Updated `LandingLayout.astro` to use `/social-preview.png` instead of non-existent `/og-image.png`

### robots.txt Issue (Manual Action Required)

The robots.txt showing AI-blocking content is from Cloudflare's **Managed robots.txt** feature, not our codebase.

**To fix:**
1. Go to [Cloudflare Dashboard](https://dash.cloudflare.com)
2. Select the scenarist.io zone
3. Navigate to: **Security Settings → Bot traffic → robots.txt setting**
4. **Disable** the managed robots.txt feature

This will serve our static `robots.txt` as-is. This is a one-time dashboard setting, not controllable via CI.

Reference: [Cloudflare Managed robots.txt docs](https://developers.cloudflare.com/bots/additional-configurations/managed-robots-txt/)

🤖 Generated with [Claude Code](https://claude.com/claude-code)