### PR TITLE
fix: make internal packages publishable to npm

### DIFF
--- a/.changeset/publish-internal-packages.md
+++ b/.changeset/publish-internal-packages.md
@@ -1,0 +1,10 @@
+---
+"@scenarist/core": patch
+"@scenarist/msw-adapter": patch
+---
+
+Make internal packages publishable to npm
+
+Previously, `@scenarist/core` and `@scenarist/msw-adapter` were marked as private, but they are dependencies of the public adapter packages. When users installed adapters from npm, these internal dependencies could not be resolved.
+
+This change makes both internal packages publishable so they will be available on npm as transitive dependencies.

--- a/internal/core/package.json
+++ b/internal/core/package.json
@@ -1,8 +1,7 @@
 {
   "name": "@scenarist/core",
   "version": "0.0.0",
-  "private": true,
-  "description": "Hexagonal architecture core for scenario-based testing with MSW",
+  "description": "Internal: Hexagonal architecture core for scenario-based testing with MSW",
   "author": "Paul Hammond (citypaul) <paul@packsoftware.co.uk>",
   "license": "MIT",
   "homepage": "https://github.com/citypaul/scenarist#readme",
@@ -25,6 +24,12 @@
     "hexagonal-architecture",
     "typescript"
   ],
+  "engines": {
+    "node": ">=18.0.0"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
   "type": "module",
   "sideEffects": false,
   "main": "./dist/index.js",

--- a/internal/msw-adapter/package.json
+++ b/internal/msw-adapter/package.json
@@ -1,10 +1,31 @@
 {
   "name": "@scenarist/msw-adapter",
   "version": "0.0.0",
-  "description": "Internal MSW integration layer for Scenarist framework adapters",
+  "description": "Internal: MSW integration layer for Scenarist framework adapters",
   "author": "Paul Hammond (citypaul) <paul@packsoftware.co.uk>",
   "license": "MIT",
-  "private": true,
+  "homepage": "https://github.com/citypaul/scenarist#readme",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/citypaul/scenarist.git",
+    "directory": "internal/msw-adapter"
+  },
+  "bugs": {
+    "url": "https://github.com/citypaul/scenarist/issues"
+  },
+  "keywords": [
+    "msw",
+    "mock-service-worker",
+    "testing",
+    "scenarist",
+    "internal"
+  ],
+  "engines": {
+    "node": ">=18.0.0"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
@@ -14,6 +35,11 @@
       "import": "./dist/index.js"
     }
   },
+  "files": [
+    "dist",
+    "README.md",
+    "LICENSE"
+  ],
   "scripts": {
     "build": "tsc",
     "dev": "tsc --watch",


### PR DESCRIPTION
## Summary

- Makes `@scenarist/core` and `@scenarist/msw-adapter` publishable to npm
- Previously, these internal packages were marked as `private: true` but they are dependencies of the public adapter packages
- When users installed adapters from npm (e.g., `@scenarist/nextjs-adapter`), these internal dependencies could not be resolved

## Changes

- Remove `private: true` from both internal packages
- Add `publishConfig: { access: "public" }` to both
- Add `engines: { node: ">=18.0.0" }` matching other packages
- Add full npm metadata to msw-adapter (homepage, repository, bugs, keywords, files)
- Update descriptions to prefix with "Internal:" to indicate they're not user-facing

## Test plan

- [x] All tests pass (`pnpm test`)
- [x] Build succeeds (`pnpm build`)
- [ ] CI passes
- [ ] After merge, verify packages are published to npm
- [ ] Verify `npm install @scenarist/nextjs-adapter` works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)