### PR TITLE
fix(release): use PAT to trigger CI on changeset PRs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -63,5 +63,6 @@ jobs:
           commit: 'chore: release packages'
           createGithubReleases: true
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # Use PAT instead of GITHUB_TOKEN to trigger CI workflows on changeset PR
+          GITHUB_TOKEN: ${{ secrets.RELEASE_PAT }}
           NPM_CONFIG_PROVENANCE: true


### PR DESCRIPTION
## Summary

- Uses a PAT (`RELEASE_PAT`) instead of `GITHUB_TOKEN` in the Release workflow
- Fixes issue where changeset release PRs have no CI checks

## Problem

When the Release workflow pushes commits to `changeset-release/main`, the CI workflow doesn't trigger because `GITHUB_TOKEN` doesn't trigger workflows on push (GitHub security feature to prevent infinite loops).

This caused PR #183 to hang with no status checks until manually closed/reopened.

## Solution

Use a Personal Access Token (PAT) which does trigger workflows on push.

## Setup Required

Before merging, add the `RELEASE_PAT` secret to the repository:

1. Go to https://github.com/settings/tokens
2. Generate new token (classic) with `repo` scope
3. Add as repository secret named `RELEASE_PAT` at https://github.com/citypaul/scenarist/settings/secrets/actions

## Test plan

- [ ] Add `RELEASE_PAT` secret to repository
- [ ] Merge this PR
- [ ] Next release should trigger CI on the changeset PR automatically

🤖 Generated with [Claude Code](https://claude.com/claude-code)