### PR TITLE
fix: republish internal packages with actual code

### DIFF
--- a/.changeset/republish-internal-packages.md
+++ b/.changeset/republish-internal-packages.md
@@ -1,0 +1,9 @@
+---
+"@scenarist/core": patch
+"@scenarist/msw-adapter": patch
+---
+
+Republish internal packages with actual code
+
+The 0.0.1 versions on npm are placeholder packages for OIDC trusted publishing setup.
+This release publishes the actual implementation code.


### PR DESCRIPTION
## Summary

Republishes `@scenarist/core` and `@scenarist/msw-adapter` with the actual implementation code.

## Problem

The 0.0.1 versions on npm are placeholder packages (~2KB each) created for OIDC trusted publishing setup:

```
@scenarist/core@0.0.1 | Proprietary | deps: none
OIDC trusted publishing setup package for @scenarist/core
```

When users install `@scenarist/nextjs-adapter`, they get these empty placeholders instead of the real code, causing:

```
Module not found: Can't resolve '@scenarist/core'
```

## Solution

Add a changeset to bump both packages to 0.0.2, which will publish the actual implementation.

## Test plan

- [ ] Merge PR
- [ ] Wait for release workflow to publish 0.0.2
- [ ] Verify `npm view @scenarist/core@0.0.2` shows real dependencies
- [ ] Test `npm install @scenarist/nextjs-adapter` in a fresh project

🤖 Generated with [Claude Code](https://claude.com/claude-code)