### PR TITLE
fix: sync internal package versions and republish with OIDC

### DIFF
--- a/.changeset/sync-versions-and-republish.md
+++ b/.changeset/sync-versions-and-republish.md
@@ -1,0 +1,9 @@
+---
+"@scenarist/core": minor
+"@scenarist/msw-adapter": minor
+---
+
+Sync internal package versions and republish with OIDC
+
+Bumps internal packages to 0.1.0 to align with adapter package versions (0.1.x).
+Previous 0.0.2 publish failed due to OIDC not being configured on npm.


### PR DESCRIPTION
## Summary

Bumps `@scenarist/core` and `@scenarist/msw-adapter` from 0.0.2 → 0.1.0

## Why

1. **Previous publish failed:** The 0.0.2 versions failed to publish because OIDC wasn't configured on npm
2. **Version alignment:** Syncs internal packages to 0.1.x to match adapter packages

## Current state

| Package | Repo | NPM |
|---------|------|-----|
| @scenarist/core | 0.0.2 | 0.0.1 (placeholder) |
| @scenarist/msw-adapter | 0.0.2 | 0.0.1 (placeholder) |
| @scenarist/express-adapter | 0.1.2 | 0.1.2 |
| @scenarist/nextjs-adapter | 0.1.2 | 0.1.2 (depends on 0.0.2!) |
| @scenarist/playwright-helpers | 0.1.2 | 0.1.2 |

## After merge

| Package | Version |
|---------|---------|
| @scenarist/core | 0.1.0 |
| @scenarist/msw-adapter | 0.1.0 |
| Adapters | 0.1.3 (updated deps) |

## Test plan

- [ ] Merge PR
- [ ] Verify release workflow publishes successfully
- [ ] Verify `npm view @scenarist/core` shows real package with dependencies
- [ ] Test `npm install @scenarist/nextjs-adapter` in fresh project

🤖 Generated with [Claude Code](https://claude.com/claude-code)