### PR TITLE
fix(ci): skip Claude review for Dependabot and fork PRs

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -12,11 +12,10 @@ on:
 
 jobs:
   claude-review:
-    # Optional: Filter by PR author
-    # if: |
-    #   github.event.pull_request.user.login == 'external-contributor' ||
-    #   github.event.pull_request.user.login == 'new-developer' ||
-    #   github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR'
+    # Skip for Dependabot and fork PRs (secrets not available)
+    if: |
+      github.actor != 'dependabot[bot]' &&
+      github.event.pull_request.head.repo.full_name == github.repository
 
     runs-on: ubuntu-latest
     permissions:


### PR DESCRIPTION
## Summary

Fixes the `claude-review` job failing on Dependabot PRs with:
```
Error: Environment variable validation failed:
- Either ANTHROPIC_API_KEY or CLAUDE_CODE_OAUTH_TOKEN is required when using direct Anthropic API.
```

**Root cause:** GitHub Actions secrets are not available to Dependabot PRs or fork PRs (security feature to prevent secret exfiltration).

## Changes

Added job condition to skip Claude review when:
1. PR author is `dependabot[bot]`
2. PR is from a fork (head repo != base repo)

```yaml
if: |
  github.actor != 'dependabot[bot]' &&
  github.event.pull_request.head.repo.full_name == github.repository
```

## Test plan

- [ ] Verify this PR's `claude-review` job runs (it's not from Dependabot)
- [ ] Verify Dependabot PRs show `claude-review` as skipped (not failed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)