### PR TITLE
fix(ci): use cdxgen for SBOM generation in pnpm workspace

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,7 +49,7 @@ jobs:
         run: pnpm build
 
       - name: Generate SBOM
-        run: npx @cyclonedx/cyclonedx-npm --output-format JSON --output-file sbom.json
+        run: npx @cyclonedx/cdxgen -o sbom.json --format json
 
       - name: Upload SBOM artifact
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
## Summary

- Replace `@cyclonedx/cyclonedx-npm` with `@cyclonedx/cdxgen` for SBOM generation in the release workflow

## Problem

The release workflow was failing at the "Generate SBOM" step because `@cyclonedx/cyclonedx-npm` uses `npm ls` internally, which doesn't work correctly with pnpm workspaces. The npm tool reports packages as "extraneous" or "missing" due to pnpm's different dependency resolution and symlink strategy.

**Failed run:** https://github.com/citypaul/scenarist/actions/runs/19746700001/job/56582290015

## Solution

Use `@cyclonedx/cdxgen` instead, which has native pnpm support and correctly handles workspace dependencies.

## Test plan

- [ ] CI pipeline passes
- [ ] Release workflow successfully generates SBOM

🤖 Generated with [Claude Code](https://claude.com/claude-code)