### PR TITLE
feat(security): add Sigstore SBOM signing to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,11 +51,19 @@ jobs:
       - name: Generate SBOM
         run: npx @cyclonedx/cdxgen -o sbom.json --format json
 
+      - name: Install Cosign
+        uses: sigstore/cosign-installer@v3
+
+      - name: Sign SBOM with Sigstore
+        run: cosign sign-blob --yes --bundle sbom.json.bundle sbom.json
+
       - name: Upload SBOM artifact
         uses: actions/upload-artifact@v4
         with:
           name: sbom
-          path: sbom.json
+          path: |
+            sbom.json
+            sbom.json.bundle
           # Extended retention for compliance/audit purposes
           retention-days: 365
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -66,6 +66,7 @@ Scenarist is designed with security in mind:
 
 - **OIDC Trusted Publishing**: npm packages are published using OIDC tokens (no stored credentials)
 - **Provenance**: npm packages include provenance attestation
+- **SBOM with Sigstore Signing**: Software Bill of Materials generated for each release, signed with Sigstore for tamper-evidence
 - **Frozen Lockfile**: CI enforces `pnpm install --frozen-lockfile`
 - **Dependency Auditing**: Automated vulnerability scanning in CI
 


### PR DESCRIPTION
## Summary

Adds cryptographic signing of the SBOM using Sigstore's keyless signing. This provides tamper-evidence for the Software Bill of Materials, allowing users to verify the SBOM was generated by our CI and hasn't been modified.

## Changes

**`.github/workflows/release.yml`:**
- Install cosign via `sigstore/cosign-installer@v3`
- Sign SBOM with `cosign sign-blob --yes --bundle sbom.json.bundle sbom.json`
- Upload both `sbom.json` and `sbom.json.bundle` as artifacts

**`SECURITY.md`:**
- Document SBOM signing in Supply Chain Security section

## How it works

1. Release workflow generates SBOM using CycloneDX
2. Cosign signs the SBOM using GitHub's OIDC token (keyless signing)
3. Signature bundle is uploaded alongside SBOM
4. Users can verify with: `cosign verify-blob --bundle sbom.json.bundle sbom.json`

## Test plan

- [ ] Verify release workflow succeeds (will test on next release)
- [ ] Verify sbom.json.bundle is created alongside sbom.json
- [ ] Verify signature can be validated with cosign

🤖 Generated with [Claude Code](https://claude.com/claude-code)