### PR TITLE
feat(ci): add security label automation for PRs

### DIFF
--- a/.github/workflows/label-security.yml
+++ b/.github/workflows/label-security.yml
@@ -1,0 +1,64 @@
+name: Label Security PRs
+
+on:
+  pull_request:
+    types: [opened, synchronize]
+    paths:
+      # Security policies and configs
+      - "SECURITY.md"
+      - ".gitleaks.toml"
+      - ".github/dependabot.yml"
+      # CI/CD workflows (potential attack vector)
+      - ".github/workflows/**"
+      - ".github/actions/**"
+      # ESLint security rules
+      - "internal/eslint-config/**"
+      # Package configs (dependency changes)
+      - "package.json"
+      - "pnpm-lock.yaml"
+      - "**/package.json"
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  label:
+    name: Add Security Label
+    runs-on: ubuntu-latest
+    steps:
+      - name: Add security label
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const { owner, repo } = context.repo;
+            const issue_number = context.issue.number;
+
+            // Check if label exists, create if not
+            try {
+              await github.rest.issues.getLabel({
+                owner,
+                repo,
+                name: 'security'
+              });
+            } catch (e) {
+              if (e.status === 404) {
+                await github.rest.issues.createLabel({
+                  owner,
+                  repo,
+                  name: 'security',
+                  color: 'd93f0b',
+                  description: 'Security-related changes requiring careful review'
+                });
+              }
+            }
+
+            // Add label to PR
+            await github.rest.issues.addLabels({
+              owner,
+              repo,
+              issue_number,
+              labels: ['security']
+            });
+
+            console.log(`Added 'security' label to PR #${issue_number}`);


### PR DESCRIPTION
## Summary

Adds automatic labeling for PRs that touch security-sensitive files. This helps maintainers quickly identify PRs that need security review.

## How it works

When a PR is opened or updated that modifies any of these paths:
- `SECURITY.md`, `.gitleaks.toml`, `.github/dependabot.yml`
- `.github/workflows/**`, `.github/actions/**`
- `internal/eslint-config/**`
- `package.json`, `pnpm-lock.yaml`, `**/package.json`

The workflow automatically:
1. Creates the `security` label if it doesn't exist (red color)
2. Adds the label to the PR

## Test plan

- [ ] Verify this PR gets the `security` label (it modifies `.github/workflows/`)
- [ ] Verify label is created with correct color and description

🤖 Generated with [Claude Code](https://claude.com/claude-code)