### PR TITLE
fix(docs): redeploy docs when package version changes

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -12,6 +12,7 @@ on:
     paths:
       - "apps/docs/**"
       - ".github/workflows/deploy-docs.yml"
+      - "packages/express-adapter/package.json"
   workflow_dispatch:
 
 concurrency:


### PR DESCRIPTION
## Summary

- The version badge on the docs landing page reads from `packages/express-adapter/package.json` at build time
- When a release happens via Changesets, the version file changes but `deploy-docs.yml` was only watching `apps/docs/**` paths
- This meant docs weren't rebuilt after releases, so the version badge showed stale versions

**Fix:** Add `packages/express-adapter/package.json` to the watched paths so docs automatically redeploy when the version number updates.

## Test plan

- [ ] Verify CI passes
- [ ] After merge, verify next release triggers docs deployment

🤖 Generated with [Claude Code](https://claude.com/claude-code)