### PR TITLE
fix(ci): use Anchore syft for SBOM generation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,7 +49,11 @@ jobs:
         run: pnpm build
 
       - name: Generate SBOM
-        run: npx @cyclonedx/cdxgen -o sbom.json --format json
+        uses: anchore/sbom-action@v0
+        with:
+          format: cyclonedx-json
+          output-file: sbom.json
+          upload-artifact: false
 
       - name: Install Cosign
         uses: sigstore/cosign-installer@v3
@@ -64,7 +68,6 @@ jobs:
           path: |
             sbom.json
             sbom.json.bundle
-          # Extended retention for compliance/audit purposes
           retention-days: 365
 
       - name: Upgrade npm for OIDC trusted publishing


### PR DESCRIPTION
## Summary

- Replace `@cyclonedx/cdxgen` with `anchore/sbom-action` for SBOM generation

## Problem

The cdxgen SBOM generator was failing CycloneDX schema validation due to a transitive dependency (tv4) having non-standard license metadata:

```json
{
  "type": "Public Domain",
  "url": "http://geraintluff.github.io/tv4/LICENSE.txt"
}
```

CycloneDX requires either `id` (SPDX identifier) or `name` property, but tv4's metadata only has `type`. This is upstream metadata we can't control.

**Failed run:** https://github.com/citypaul/scenarist/actions/runs/19747077495/job/56583380898

## Solution

Switch to [Anchore's syft](https://github.com/anchore/syft) via the official `anchore/sbom-action`. Benefits:

| Feature | cdxgen | syft |
|---------|--------|------|
| Edge case handling | Strict validation fails on non-standard metadata | More graceful handling |
| Industry adoption | Growing | Widely adopted (CNCF project) |
| Maintenance | Community | Anchore (dedicated team) |
| GitHub Action | Manual npx | Official action with good defaults |

The workflow still:
- ✅ Generates CycloneDX JSON format SBOM
- ✅ Signs with Sigstore/Cosign
- ✅ Uploads artifact with 365-day retention

## Test plan

- [ ] CI pipeline passes
- [ ] Release workflow generates and signs SBOM successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)