### PR TITLE
fix(docs): correct supported versions in SECURITY.md

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,8 +4,9 @@
 
 | Version | Supported          |
 | ------- | ------------------ |
-| 1.x.x   | :white_check_mark: |
-| < 1.0   | :x:                |
+| 0.1.x   | :white_check_mark: |
+
+> **Note:** Scenarist is currently in pre-1.0 development. Once v1.0 is released, we will maintain security support for the latest minor version.
 
 ## Reporting a Vulnerability
 


### PR DESCRIPTION
## Summary

SECURITY.md claimed "1.x.x supported" but all packages are currently at 0.1.x. v1.0 hasn't been released yet.

## Verification

```bash
$ npm view @scenarist/core version
0.1.0

$ npm view @scenarist/express-adapter version
0.1.3
```

## Changes

Updated supported versions table to reflect pre-1.0 status:

**Before:**
| Version | Supported |
|---------|-----------|
| 1.x.x   | ✅ |
| < 1.0   | ❌ |

**After:**
| Version | Supported |
|---------|-----------|
| 0.1.x   | ✅ |

Added note explaining pre-1.0 status and future support policy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)