### PR TITLE
fix(ci): use correct commit SHA for codeql-action

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -33,16 +33,16 @@ jobs:
         uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@c00e4aee0547167576bc6663920491135a3dee27 # v4
+        uses: github/codeql-action/init@fdbfb4d2750291e159f0156def62b853c2798ca2 # v4
         with:
           languages: ${{ matrix.language }}
           # Use security-extended for more comprehensive security checks
           queries: security-extended,security-and-quality
 
       - name: Autobuild
-        uses: github/codeql-action/autobuild@c00e4aee0547167576bc6663920491135a3dee27 # v4
+        uses: github/codeql-action/autobuild@fdbfb4d2750291e159f0156def62b853c2798ca2 # v4
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@c00e4aee0547167576bc6663920491135a3dee27 # v4
+        uses: github/codeql-action/analyze@fdbfb4d2750291e159f0156def62b853c2798ca2 # v4
         with:
           category: "/language:${{matrix.language}}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,7 +49,7 @@ jobs:
         run: pnpm build
 
       - name: Generate SBOM
-        uses: anchore/sbom-action@f6c3d0fe42c3cf876e3462574e4c9416b5e0f07a # v0.9.0
+        uses: anchore/sbom-action@8e94d75ddd33f69f691467e42275782e4bfefe84 # v0.20.9
         with:
           format: cyclonedx-json
           output-file: sbom.json

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -37,6 +37,6 @@ jobs:
           publish_results: true
 
       - name: Upload to code-scanning
-        uses: github/codeql-action/upload-sarif@c00e4aee0547167576bc6663920491135a3dee27 # v4
+        uses: github/codeql-action/upload-sarif@fdbfb4d2750291e159f0156def62b853c2798ca2 # v4
         with:
           sarif_file: results.sarif

--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -32,7 +32,7 @@ jobs:
         run: semgrep scan --config auto --sarif --output semgrep.sarif .
 
       - name: Upload SARIF results
-        uses: github/codeql-action/upload-sarif@c00e4aee0547167576bc6663920491135a3dee27 # v4
+        uses: github/codeql-action/upload-sarif@fdbfb4d2750291e159f0156def62b853c2798ca2 # v4
         if: always()
         with:
           sarif_file: semgrep.sarif


### PR DESCRIPTION
## Summary

Fixes two CI workflow failures:

### 1. OpenSSF Scorecard - CodeQL Action SHA

The previous SHA (`c00e4aee0547167576bc6663920491135a3dee27`) was the **tag object SHA**, not the actual commit SHA. OpenSSF Scorecard's verification system rejected it as an "imposter commit":

```
error: imposter commit: c00e4aee0547167576bc6663920491135a3dee27 does not belong to github/codeql-action/upload-sarif
```

**Fix:** Updated to use the **dereferenced commit SHA** (`fdbfb4d2750291e159f0156def62b853c2798ca2`) that the `v4` tag actually points to.

### 2. Release Workflow - SBOM Action Version

The `anchore/sbom-action@v0.9.0` doesn't support the `output-file` and `upload-artifact` parameters:

```
##[warning]Unexpected input(s) 'output-file', 'upload-artifact', valid inputs are [...]
Error: signing sbom.json: open sbom.json: no such file or directory
```

**Fix:** Updated to `anchore/sbom-action@v0.20.9` which supports these parameters.

## Files Changed

- `.github/workflows/codeql.yml` - 3 occurrences (init, autobuild, analyze)
- `.github/workflows/scorecard.yml` - 1 occurrence (upload-sarif)
- `.github/workflows/semgrep.yml` - 1 occurrence (upload-sarif)
- `.github/workflows/release.yml` - 1 occurrence (sbom-action v0.9.0 → v0.20.9)

## Test plan

- [ ] Scorecard workflow passes after merge
- [ ] Release workflow passes (SBOM generation works)

🤖 Generated with [Claude Code](https://claude.com/claude-code)