### PR TITLE
fix(security): address remaining code scanning alerts

### DIFF
--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -11,14 +11,16 @@ concurrency:
   cancel-in-progress: false
 
 permissions:
-  contents: write
-  pull-requests: write
-  id-token: write
+  contents: read
 
 jobs:
   pre-release:
     name: Pre-Release
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+      id-token: write
     steps:
       - name: Checkout
         uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
@@ -81,9 +83,11 @@ jobs:
           git diff --staged --quiet || git commit -m "chore: version packages for ${{ steps.tag.outputs.tag }}"
           git push
 
+      # Pin npm version for supply chain security
+      # @see https://github.com/citypaul/scenarist/security/code-scanning/56
       - name: Upgrade npm for OIDC trusted publishing
         run: |
-          npm install -g npm@latest
+          npm install -g npm@11.6.4
           echo "npm version: $(npm --version)"
 
       - name: Publish to npm

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,14 +13,16 @@ concurrency:
   cancel-in-progress: false
 
 permissions:
-  contents: write
-  pull-requests: write
-  id-token: write
+  contents: read
 
 jobs:
   release:
     name: Release
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+      id-token: write
     # Only run if CI succeeded
     if: ${{ github.event.workflow_run.conclusion == 'success' }}
     steps:
@@ -48,9 +50,11 @@ jobs:
       - name: Build packages
         run: pnpm build
 
+      # Pin npm version for supply chain security
+      # @see https://github.com/citypaul/scenarist/security/code-scanning/57
       - name: Upgrade npm for OIDC trusted publishing
         run: |
-          npm install -g npm@latest
+          npm install -g npm@11.6.4
           echo "npm version: $(npm --version)"
 
       - name: Create Release Pull Request or Publish


### PR DESCRIPTION
## Summary

Address all remaining GitHub code scanning alerts through workflow fixes and appropriate dismissals.

## Code Changes (4 alerts)

| Alert | Severity | Issue | Fix |
|-------|----------|-------|-----|
| [Alert 56](https://github.com/citypaul/scenarist/security/code-scanning/56) | Medium | Unpinned npm dependency in pre-release.yml | Pin to `npm@11.6.4` |
| [Alert 57](https://github.com/citypaul/scenarist/security/code-scanning/57) | Medium | Unpinned npm dependency in release.yml | Pin to `npm@11.6.4` |
| [Alert 62](https://github.com/citypaul/scenarist/security/code-scanning/62) | High | Workflow-level token permissions in pre-release.yml | Move to job level |
| [Alert 63](https://github.com/citypaul/scenarist/security/code-scanning/63) | High | Workflow-level token permissions in release.yml | Move to job level |

## Dismissed Alerts (8 alerts)

| Alert | Rule | Reason | Dismissal Type |
|-------|------|--------|----------------|
| [Alert 1](https://github.com/citypaul/scenarist/security/code-scanning/1) | CSRF middleware | Example app with GET-only endpoints, no state-changing operations | Used in tests |
| [Alert 2](https://github.com/citypaul/scenarist/security/code-scanning/2) | Non-literal RegExp | Intentional design - security via Zod schema + redos-detector at trust boundary | Won't fix |
| [Alert 3](https://github.com/citypaul/scenarist/security/code-scanning/3) | Branch Protection | GitHub repo settings, not code-fixable | Won't fix |
| [Alert 66](https://github.com/citypaul/scenarist/security/code-scanning/66) | CII Best Practices | Certification process, not code | Won't fix |
| [Alert 67](https://github.com/citypaul/scenarist/security/code-scanning/67) | Code Review | Enforced via PR process | Won't fix |
| [Alert 69](https://github.com/citypaul/scenarist/security/code-scanning/69) | Maintained | Activity metric - project <90 days old | Won't fix |
| [Alert 70](https://github.com/citypaul/scenarist/security/code-scanning/70) | SAST | CodeQL/Semgrep ARE configured in workflows | Won't fix |
| [Alert 71](https://github.com/citypaul/scenarist/security/code-scanning/71) | Vulnerabilities | Known transitive lodash.set dep via @usebruno/cli (dev-only) | Won't fix |

## Test plan

- [x] Workflow syntax validated
- [x] All dismissals include explanatory comments
- [x] Remaining open alerts (4) will be auto-closed when PR merges

🤖 Generated with [Claude Code](https://claude.com/claude-code)