### PR TITLE
chore: add Prettier pre-commit hook

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,1 @@
+pnpm format

--- a/apps/docs/CONTRIBUTING.md
+++ b/apps/docs/CONTRIBUTING.md
@@ -46,7 +46,7 @@ Next.js
 
 **Always specify language identifiers** for syntax highlighting:
 
-````markdown
+`````markdown
 ✅ CORRECT:
 
 ````bash
@@ -66,7 +66,9 @@ npm install @scenarist/express-adapter
 export const scenarios = { ... };
 \```
 ````
-````
+`````
+
+`````
 
 ### Supported Language Identifiers
 
@@ -222,7 +224,8 @@ export function example() {
   // Implementation
 }
 \```
-````
+`````
+
 ````
 
 ## Consistency Checklist
@@ -378,3 +381,4 @@ sidebar: [
 ## Questions?
 
 If you're unsure about documentation standards, check existing framework documentation (Express, Next.js App Router, Next.js Pages Router) for reference examples.
+````

--- a/docs/production-readiness-assessment.md
+++ b/docs/production-readiness-assessment.md
@@ -148,6 +148,7 @@ Scenarist is **80% ready for production release**. The core architecture, testin
 - **Verification:** Both Next.js example apps (App Router & Pages Router) successfully verified with `pnpm verify:treeshaking` - zero MSW code in production bundles
 
 5. Set up Changesets workflow (4 hours):
+
    ```bash
    pnpm add -Dw @changesets/cli
    pnpm changeset init
@@ -178,6 +179,7 @@ Scenarist is **80% ready for production release**. The core architecture, testin
    ```
 
 6. Test dry-run npm publish (1 hour):
+
    ```bash
    pnpm --filter=@scenarist/core exec npm publish --dry-run
    ```

--- a/package.json
+++ b/package.json
@@ -9,11 +9,13 @@
     "lint": "turbo run lint",
     "format": "prettier --write \"**/*.{ts,tsx,md}\"",
     "typecheck": "turbo run typecheck",
-    "license:check": "license-checker --summary --excludePrivatePackages --onlyAllow 'MIT;Apache-2.0;ISC;BSD-2-Clause;BSD-3-Clause;0BSD;CC0-1.0;CC-BY-3.0;CC-BY-4.0;Unlicense;Python-2.0;BlueOak-1.0.0;MPL-2.0'"
+    "license:check": "license-checker --summary --excludePrivatePackages --onlyAllow 'MIT;Apache-2.0;ISC;BSD-2-Clause;BSD-3-Clause;0BSD;CC0-1.0;CC-BY-3.0;CC-BY-4.0;Unlicense;Python-2.0;BlueOak-1.0.0;MPL-2.0'",
+    "prepare": "husky"
   },
   "devDependencies": {
     "@changesets/changelog-github": "^0.5.2",
     "@changesets/cli": "^2.29.8",
+    "husky": "^9.1.7",
     "license-checker": "^25.0.1",
     "prettier": "^3.7.1",
     "turbo": "^2.6.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -22,6 +22,9 @@ importers:
       '@changesets/cli':
         specifier: ^2.29.8
         version: 2.29.8(@types/node@24.10.1)
+      husky:
+        specifier: ^9.1.7
+        version: 9.1.7
       license-checker:
         specifier: ^25.0.1
         version: 25.0.1
@@ -5415,6 +5418,11 @@ packages:
 
   human-id@4.1.2:
     resolution: {integrity: sha512-v/J+4Z/1eIJovEBdlV5TYj1IR+ZiohcYGRY+qN/oC9dAfKzVT023N/Bgw37hrKCoVRBvk3bqyzpr2PP5YeTMSg==}
+    hasBin: true
+
+  husky@9.1.7:
+    resolution: {integrity: sha512-5gs5ytaNjBrh5Ow3zrvdUUY+0VxIuWVL4i9irt6friV+BqdCfmV11CQTWMiBYWHbXhco+J1kHfTOUkePhCDvMA==}
+    engines: {node: '>=18'}
     hasBin: true
 
   i18next@23.16.8:
@@ -14818,6 +14826,8 @@ snapshots:
       - supports-color
 
   human-id@4.1.2: {}
+
+  husky@9.1.7: {}
 
   i18next@23.16.8:
     dependencies:


### PR DESCRIPTION
## Summary

- Add Husky with a pre-commit hook that runs Prettier on all files
- The hook runs `pnpm format` which executes `prettier --write "**/*.{ts,tsx,md}"`
- Includes `prepare` script to ensure Husky is set up on `pnpm install`

## Changes

- `.husky/pre-commit` - Pre-commit hook that runs Prettier
- `package.json` - Added Husky dependency and prepare script

## Test plan

- [x] Pre-commit hook runs on commit (verified - caught 2 files that needed formatting)
- [ ] Verify `pnpm install` sets up Husky correctly for new clones

🤖 Generated with [Claude Code](https://claude.com/claude-code)