### PR TITLE
fix: narrow security label paths to security-specific files

### DIFF
--- a/.github/workflows/label-security.yml
+++ b/.github/workflows/label-security.yml
@@ -8,15 +8,13 @@ on:
       - "SECURITY.md"
       - ".gitleaks.toml"
       - ".github/dependabot.yml"
-      # CI/CD workflows (potential attack vector)
-      - ".github/workflows/**"
-      - ".github/actions/**"
-      # ESLint security rules
-      - "internal/eslint-config/**"
-      # Package configs (dependency changes)
-      - "package.json"
-      - "pnpm-lock.yaml"
-      - "**/package.json"
+      # Security-specific workflows only (not all workflows)
+      - ".github/workflows/codeql.yml"
+      - ".github/workflows/scorecard.yml"
+      - ".github/workflows/semgrep.yml"
+      - ".github/workflows/secrets-scan.yml"
+      - ".github/workflows/dependency-review.yml"
+      - ".github/workflows/label-security.yml"
 
 permissions:
   contents: read


### PR DESCRIPTION
## Summary

- Fix overly broad path filters that caused the security label to be added to most PRs
- Remove paths that aren't security-specific: all workflows, all actions, eslint config, all package.json/lockfile changes
- Now only triggers on actual security files: SECURITY.md, .gitleaks.toml, dependabot.yml, and security-specific workflows

## Test plan

- [ ] Verify PRs that only touch non-security files (e.g., source code, docs) no longer get the security label
- [ ] Verify PRs that touch security workflows (codeql.yml, semgrep.yml, etc.) still get the label

🤖 Generated with [Claude Code](https://claude.com/claude-code)