### PR TITLE
perf(docs): self-host fonts via @fontsource for improved Lighthouse scores

### DIFF
--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -20,6 +20,8 @@
     "@astrojs/cloudflare": "^12.6.12",
     "@astrojs/sitemap": "^3.6.0",
     "@astrojs/starlight": "^0.36.3",
+    "@fontsource-variable/inter": "^5.2.8",
+    "@fontsource-variable/jetbrains-mono": "^5.2.8",
     "astro": "^5.16.2",
     "rehype-mermaid": "^3.0.0",
     "sharp": "^0.34.5"

--- a/apps/docs/src/layouts/LandingLayout.astro
+++ b/apps/docs/src/layouts/LandingLayout.astro
@@ -1,5 +1,7 @@
 ---
 import '../styles/global.css';
+import '@fontsource-variable/inter';
+import '@fontsource-variable/jetbrains-mono';
 
 interface Props {
   title: string;
@@ -16,7 +18,6 @@ const {
 } = Astro.props;
 
 const siteName = 'Scenarist';
-const twitterHandle = '@scenarist';
 ---
 
 <!DOCTYPE html>
@@ -53,10 +54,7 @@ const twitterHandle = '@scenarist';
   <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
   <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png" />
 
-  <!-- Fonts -->
-  <link rel="preconnect" href="https://fonts.googleapis.com" />
-  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700;800&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet" />
+  <!-- Fonts are self-hosted via @fontsource for optimal performance -->
 
   <!-- Theme Color -->
   <meta name="theme-color" content="#8B5CF6" />

--- a/apps/docs/src/styles/custom.css
+++ b/apps/docs/src/styles/custom.css
@@ -1,13 +1,14 @@
 /* Scenarist Documentation Custom Styles */
 
-/* ===== FONTS ===== */
-@import url('https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700;800&family=JetBrains+Mono:wght@400;500&display=swap');
+/* ===== FONTS (self-hosted via Fontsource for performance) ===== */
+@import '@fontsource-variable/inter';
+@import '@fontsource-variable/jetbrains-mono';
 
 /* ===== DESIGN TOKENS ===== */
 :root {
-  /* Typography */
-  --sl-font: 'Inter', system-ui, sans-serif;
-  --sl-font-mono: 'JetBrains Mono', monospace;
+  /* Typography - using variable fonts for performance */
+  --sl-font: 'Inter Variable', 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  --sl-font-mono: 'JetBrains Mono Variable', 'JetBrains Mono', ui-monospace, 'SF Mono', Menlo, Monaco, monospace;
 
   /* Dark Mode Colors (Starlight default is dark) */
   --sl-color-bg: #030304;

--- a/apps/docs/src/styles/global.css
+++ b/apps/docs/src/styles/global.css
@@ -5,9 +5,9 @@
 
 /* Tailwind v4 Theme Configuration */
 @theme {
-  /* Font families */
-  --font-sans: 'Inter', system-ui, sans-serif;
-  --font-mono: 'JetBrains Mono', monospace;
+  /* Font families - using variable fonts for performance */
+  --font-sans: 'Inter Variable', 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  --font-mono: 'JetBrains Mono Variable', 'JetBrains Mono', ui-monospace, 'SF Mono', Menlo, Monaco, monospace;
 
   /* Dark mode colors (base) */
   --color-dark-bg: #030304;
@@ -50,6 +50,12 @@
   body {
     -webkit-font-smoothing: antialiased;
     -moz-osx-font-smoothing: grayscale;
+  }
+
+  /* Prevent layout shift during font loading by ensuring text rendering is stable */
+  h1, h2, h3, h4, h5, h6, p {
+    font-synthesis: none;
+    text-rendering: optimizeLegibility;
   }
 
   /* Selection styling */

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -52,6 +52,12 @@ importers:
       '@astrojs/starlight':
         specifier: ^0.36.3
         version: 0.36.3(astro@5.16.2(@types/node@24.10.1)(jiti@2.6.1)(lightningcss@1.30.2)(rollup@4.53.3)(tsx@4.20.6)(typescript@5.9.3)(yaml@2.8.1))
+      '@fontsource-variable/inter':
+        specifier: ^5.2.8
+        version: 5.2.8
+      '@fontsource-variable/jetbrains-mono':
+        specifier: ^5.2.8
+        version: 5.2.8
       astro:
         specifier: ^5.16.2
         version: 5.16.2(@types/node@24.10.1)(jiti@2.6.1)(lightningcss@1.30.2)(rollup@4.53.3)(tsx@4.20.6)(typescript@5.9.3)(yaml@2.8.1)
@@ -1772,6 +1778,12 @@ packages:
   '@faker-js/faker@9.9.0':
     resolution: {integrity: sha512-OEl393iCOoo/z8bMezRlJu+GlRGlsKbUAN7jKB6LhnKoqKve5DXRpalbItIIcwnCjs1k/FOPjFzcA6Qn+H+YbA==}
     engines: {node: '>=18.0.0', npm: '>=9.0.0'}
+
+  '@fontsource-variable/inter@5.2.8':
+    resolution: {integrity: sha512-kOfP2D+ykbcX/P3IFnokOhVRNoTozo5/JxhAIVYLpea/UBmCQ/YWPBfWIDuBImXX/15KH+eKh4xpEUyS2sQQGQ==}
+
+  '@fontsource-variable/jetbrains-mono@5.2.8':
+    resolution: {integrity: sha512-WBA9elru6Jdp5df2mES55wuOO0WIrn3kpXnI4+W2ek5u3ZgLS9XS4gmIlcQhiZOWEKl95meYdvK7xI+ETLCq/Q==}
 
   '@formatjs/ecma402-abstract@2.3.6':
     resolution: {integrity: sha512-HJnTFeRM2kVFVr5gr5kH1XP6K0JcJtE7Lzvtr3FS/so5f1kpsqqqxy5JF+FRaO6H2qmcMfAUIox7AJteieRtVw==}
@@ -10447,6 +10459,10 @@ snapshots:
       '@expressive-code/core': 0.41.3
 
   '@faker-js/faker@9.9.0': {}
+
+  '@fontsource-variable/inter@5.2.8': {}
+
+  '@fontsource-variable/jetbrains-mono@5.2.8': {}
 
   '@formatjs/ecma402-abstract@2.3.6':
     dependencies:


### PR DESCRIPTION
## Summary

- Replace Google Fonts CDN with self-hosted @fontsource variable fonts
- Eliminate render-blocking requests and layout shifts from external font loading
- Add `@fontsource-variable/inter` and `@fontsource-variable/jetbrains-mono` packages

## Problem

Lighthouse identified the following issues on the production docs site:
- **Render-blocking resources**: ~1,790ms savings available (Google Fonts CSS blocking initial render)
- **Layout shift (CLS 0.194)**: Text shifting when fonts loaded from external CDN
- **Network dependency chain**: Maximum critical path latency of 251ms due to font chain
- **No preconnect hints**: Missing preconnect to fonts.googleapis.com

## Solution

Self-host fonts using @fontsource packages which:
1. Bundles font files directly with the build (no external requests)
2. Eliminates render-blocking behavior
3. Reduces network latency (fonts served from same origin)
4. Prevents CLS by ensuring consistent font loading

## Changes

- Added `@fontsource-variable/inter` and `@fontsource-variable/jetbrains-mono` dependencies
- Removed Google Fonts `<link>` tags from `LandingLayout.astro`
- Replaced CSS `@import url()` with local `@fontsource` imports in `custom.css`
- Updated font-family stacks to use variable font names with proper fallbacks
- Added `font-synthesis: none` for consistent text rendering

## Test Results

```
Landing Page (Desktop): Performance: 100 | Accessibility: 100 | Best Practices: 100 | SEO: 100
Landing Page (Mobile): Performance: 99 | Accessibility: 100 | Best Practices: 100 | SEO: 100
Quick Start (Desktop): Performance: 100 | Accessibility: 100 | Best Practices: 100 | SEO: 100
Quick Start (Mobile): Performance: 99 | Accessibility: 100 | Best Practices: 100 | SEO: 100
```

## Test Plan

- [x] Build succeeds with no Google Fonts references in output
- [x] Fonts are bundled as woff2 files in `dist/_astro/`
- [x] Lighthouse tests pass with 99-100 performance scores
- [x] TypeScript check passes
- [x] All Playwright tests pass (16/16)

🤖 Generated with [Claude Code](https://claude.com/claude-code)