### PR TITLE
fix(docs): resolve iOS Safari scrolling jank and nav bar snapping

### DIFF
--- a/apps/docs/src/layouts/LandingLayout.astro
+++ b/apps/docs/src/layouts/LandingLayout.astro
@@ -24,7 +24,7 @@ const siteName = 'Scenarist';
 <html lang="en" class="dark">
 <head>
   <meta charset="UTF-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
 
   <!-- Primary Meta Tags -->
   <title>{title}</title>

--- a/apps/docs/src/styles/custom.css
+++ b/apps/docs/src/styles/custom.css
@@ -4,6 +4,28 @@
 @import '@fontsource-variable/inter';
 @import '@fontsource-variable/jetbrains-mono';
 
+/* ===== iOS SCROLLING FIX ===== */
+/* Prevents janky scrolling and nav bar snapping on iOS Safari */
+html {
+  /* Prevent iOS overscroll bounce that causes nav bar jank */
+  overscroll-behavior: none;
+}
+
+body {
+  /* Prevent iOS overscroll bounce on body */
+  overscroll-behavior-y: none;
+  /* Disable double-tap zoom for faster interactions */
+  touch-action: manipulation;
+}
+
+/* iOS Safari: ensure fixed/sticky elements don't jank during address bar animation */
+@supports (-webkit-touch-callout: none) {
+  body {
+    /* Use min-height with -webkit-fill-available for iOS viewport stability */
+    min-height: -webkit-fill-available;
+  }
+}
+
 /* ===== DESIGN TOKENS ===== */
 :root {
   /* Typography - using variable fonts for performance */

--- a/apps/docs/src/styles/global.css
+++ b/apps/docs/src/styles/global.css
@@ -45,11 +45,25 @@
   html {
     font-family: var(--font-sans);
     scroll-behavior: smooth;
+    /* Prevent iOS overscroll bounce that causes nav bar jank */
+    overscroll-behavior: none;
   }
 
   body {
     -webkit-font-smoothing: antialiased;
     -moz-osx-font-smoothing: grayscale;
+    /* Prevent iOS overscroll bounce on body */
+    overscroll-behavior-y: none;
+    /* Disable double-tap zoom for faster interactions */
+    touch-action: manipulation;
+  }
+
+  /* iOS Safari: ensure fixed elements don't jank during address bar animation */
+  @supports (-webkit-touch-callout: none) {
+    body {
+      /* Use min-height with -webkit-fill-available for iOS viewport stability */
+      min-height: -webkit-fill-available;
+    }
   }
 
   /* Prevent layout shift during font loading by ensuring text rendering is stable */


### PR DESCRIPTION
## Summary
- Fixes janky scrolling behavior on iOS Safari caused by the dynamic viewport (address bar showing/hiding)
- Adds `overscroll-behavior: none` to prevent rubber-band bounce effects
- Adds `touch-action: manipulation` to disable double-tap zoom delay
- Uses `-webkit-fill-available` for iOS viewport stability
- Adds `viewport-fit=cover` meta tag for notched device support

## Test plan
- [ ] Test on iOS Safari (real device preferred) - scroll aggressively and verify nav bar no longer snaps
- [ ] Test on Android Chrome - verify no regression
- [ ] Verify docs site builds successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)