### PR TITLE
perf(ci): skip expensive CI jobs for version-only commits

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,9 +14,37 @@ permissions:
   contents: read
 
 jobs:
-  # Job 0: Security Audit (runs early to fail fast on vulnerabilities)
+  # Job 0: Detect what changed (enables skipping CI for version-only commits)
+  detect-changes:
+    name: Detect Changes
+    runs-on: ubuntu-latest
+    outputs:
+      code_changed: ${{ steps.filter.outputs.code }}
+    steps:
+      - name: Check out code
+        uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
+
+      - name: Detect code changes
+        uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2
+        id: filter
+        with:
+          filters: |
+            code:
+              - 'packages/**'
+              - 'internal/**'
+              - 'apps/**'
+              - '.github/**'
+              - 'package.json'
+              - 'pnpm-lock.yaml'
+              - 'turbo.json'
+              - '!**/CHANGELOG.md'
+
+  # Job 1: Security Audit (runs early to fail fast on vulnerabilities)
+  # Skipped for version-only commits (no new dependencies)
   security-audit:
     name: Security Audit
+    needs: detect-changes
+    if: needs.detect-changes.outputs.code_changed == 'true'
     timeout-minutes: 5
     runs-on: ubuntu-latest
 
@@ -51,9 +79,12 @@ jobs:
       - name: Check licenses
         run: pnpm license:check
 
-  # Job 1: Setup and Build (shared by all other jobs)
+  # Job 2: Setup and Build (shared by all other jobs)
+  # Skipped for version-only commits (no code to build)
   setup-and-build:
     name: Setup and Build
+    needs: detect-changes
+    if: needs.detect-changes.outputs.code_changed == 'true'
     timeout-minutes: 10
     runs-on: ubuntu-latest
 
@@ -328,3 +359,22 @@ jobs:
 
       - name: Run custom server tests
         run: pnpm --filter=${{ matrix.filter }} test:custom
+
+  # Job 10: Release Gate (always runs to ensure CI completes for release workflow)
+  # This job serves as a "success signal" for the release workflow, which triggers
+  # when CI completes on main. For version-only commits (no code changes), this
+  # is the only job that runs, allowing fast-path releases.
+  release-gate:
+    name: Release Gate
+    runs-on: ubuntu-latest
+    needs: detect-changes
+    if: always()
+    steps:
+      - name: Check CI status
+        run: |
+          echo "Code changed: ${{ needs.detect-changes.outputs.code_changed }}"
+          if [[ "${{ needs.detect-changes.outputs.code_changed }}" == "true" ]]; then
+            echo "Full CI completed - code was tested"
+          else
+            echo "Fast-path CI - version/changelog only changes detected"
+          fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -57,16 +57,17 @@ jobs:
           npm install -g npm@11.6.4
           echo "npm version: $(npm --version)"
 
-      - name: Version and Publish
+      - name: Create Release Pull Request or Publish
         id: changesets
         uses: changesets/action@8eb63fb4cfc7f9643537c7d39d0b68c835012a19 # v1.5.3
         with:
           version: pnpm changeset version
           publish: pnpm changeset publish
+          title: 'chore: release packages'
           commit: 'chore: release packages'
           createGithubReleases: true
         env:
-          # PAT required to push version commits directly to main
+          # PAT required to create Version PR and push to changeset-release branch
           GITHUB_TOKEN: ${{ secrets.RELEASE_PAT }}
           NPM_CONFIG_PROVENANCE: true
 


### PR DESCRIPTION
## Summary

Optimizes the release process by skipping expensive CI jobs when merging Version PRs (which only contain version bumps and CHANGELOGs).

## Problem

Previously, merging a Version PR triggered the full CI suite (~10 minutes) even though it contains no code changes - just:
- `package.json` version bumps
- `CHANGELOG.md` updates  
- Deleted `.changeset/*.md` files

## Solution

Add path-based change detection to CI. When only version/changelog files change:
- Skip `security-audit` (no new dependencies)
- Skip `setup-and-build` (no code to build)
- Skip all test jobs (no code to test)
- Run only `detect-changes` + `release-gate` (~30 seconds)

## Changes

### `.github/workflows/ci.yml`
- Add `detect-changes` job using `dorny/paths-filter`
- Make `security-audit` and `setup-and-build` conditional on `code_changed == 'true'`
- Add `release-gate` job that always succeeds (ensures release workflow triggers)

### `.github/workflows/release.yml`
- Restore `title:` parameter to `changesets/action` (creates Version PRs)
- Update comment to reflect PR workflow

### `docs/release/release-process.md`
- Document the Version PR workflow
- Update PAT permissions to include `Pull requests: Read and write`
- Explain fast-path CI for version-only commits

## New Release Flow

```
Feature PR → Full CI (~10 min) → Merge
    ↓
CI on main (~10 min) → Version PR created
    ↓
Merge Version PR → Fast CI (~30 sec) → Publish to npm
```

## PAT Requirements

The `RELEASE_PAT` now needs:

| Permission | Access |
|------------|--------|
| Contents | Read and write |
| Pull requests | Read and write |
| Metadata | Read-only (auto-selected) |

## Test plan

- [ ] CI passes on this PR (full CI since it has code changes)
- [ ] After merge, verify Version PR is created (there's a pending changeset)
- [ ] Merge Version PR and verify fast-path CI runs (~30 seconds)
- [ ] Verify publish succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)