### PR TITLE
fix(ci): put exclusion patterns before inclusions in paths-filter

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,30 +31,38 @@ jobs:
           # Detects actual code changes vs version-only changes (from Version PRs)
           # Version PRs modify: package.json, CHANGELOG.md, .changeset/ (all excluded below)
           # This allows Version PR merges to get fast-path CI (~30s vs ~10min)
+          #
+          # IMPORTANT: Exclusions MUST come BEFORE inclusions!
+          # dorny/paths-filter uses "first match wins" - if a file matches an
+          # inclusion pattern before an exclusion, it will be included.
           filters: |
             code:
+              # Exclusions first (Version PR files) - order matters!
+              # dorny/paths-filter uses "first match wins"
+              - '!packages/**/package.json'
+              - '!packages/**/CHANGELOG.md'
+              - '!packages/**/test-results/**'
+              - '!internal/**/package.json'
+              - '!internal/**/CHANGELOG.md'
+              - '!internal/**/test-results/**'
+              - '!apps/**/package.json'
+              - '!apps/**/CHANGELOG.md'
+              - '!apps/**/test-results/**'
+              - '!.changeset/**'
+              # Then inclusions (files not matched above)
               - 'packages/**/*.ts'
               - 'packages/**/*.tsx'
               - 'packages/**/*.js'
               - 'packages/**/*.mjs'
               - 'packages/**/*.cjs'
               - 'packages/**/*.json'
-              - '!packages/**/package.json'
-              - '!packages/**/CHANGELOG.md'
-              - '!packages/**/test-results/**'
               - 'internal/**/*.ts'
               - 'internal/**/*.tsx'
               - 'internal/**/*.js'
               - 'internal/**/*.mjs'
               - 'internal/**/*.cjs'
               - 'internal/**/*.json'
-              - '!internal/**/package.json'
-              - '!internal/**/CHANGELOG.md'
-              - '!internal/**/test-results/**'
               - 'apps/**'
-              - '!apps/**/CHANGELOG.md'
-              - '!apps/**/test-results/**'
-              - '!.changeset/**'
               - '.github/**'
               - 'package.json'
               - 'pnpm-lock.yaml'


### PR DESCRIPTION
## Summary

Fixes Version PRs running full CI instead of fast-path CI.

## Root Cause

`dorny/paths-filter` uses **first match wins** semantics. When a file matches a pattern, evaluation stops - subsequent patterns (including exclusions) are never checked.

**Previous order (broken):**
```yaml
- 'packages/**/*.json'        # package.json matches here → INCLUDED ❌
- '!packages/**/package.json' # never evaluated
```

**Fixed order:**
```yaml
- '!packages/**/package.json' # package.json matches here → EXCLUDED ✅
- 'packages/**/*.json'        # tsconfig.json matches here → INCLUDED ✅
```

## Changes

- Move all exclusion patterns (`!...`) before inclusion patterns
- Add comments explaining the "first match wins" behavior
- Ensures Version PRs get fast-path CI (~30s) instead of full CI (~10min)

## Test plan

1. Close PR #278 (current Version PR running full CI)
2. Merge this PR
3. New Version PR will be created by release workflow
4. Verify new Version PR only runs `detect-changes` and `release-gate` jobs

🤖 Generated with [Claude Code](https://claude.com/claude-code)