### PR TITLE
fix(ci): skip expensive checks for Version PRs

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -28,13 +28,23 @@ jobs:
       id-token: write
 
     steps:
-      - name: Check if workflow file changed
-        id: workflow-changed
+      - name: Check if should skip review
+        id: should-skip
         env:
           GH_TOKEN: ${{ github.token }}
+          HEAD_REF: ${{ github.head_ref }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
         run: |
+          # Skip for Version PRs (only version bumps and CHANGELOG updates)
+          if [[ "$HEAD_REF" == "changeset-release/main" ]]; then
+            echo "Version PR detected - skipping Claude review"
+            echo "skip=true" >> $GITHUB_OUTPUT
+            exit 0
+          fi
+
           # Get list of changed files in this PR
-          CHANGED_FILES=$(gh pr diff ${{ github.event.pull_request.number }} --name-only --repo ${{ github.repository }})
+          CHANGED_FILES=$(gh pr diff "$PR_NUMBER" --name-only --repo "$REPO")
 
           # Check if this workflow file is in the changed files
           if echo "$CHANGED_FILES" | grep -q "^.github/workflows/claude-code-review.yml$"; then
@@ -45,13 +55,13 @@ jobs:
           fi
 
       - name: Checkout repository
-        if: steps.workflow-changed.outputs.skip != 'true'
+        if: steps.should-skip.outputs.skip != 'true'
         uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
         with:
           fetch-depth: 1
 
       - name: Run Claude Code Review
-        if: steps.workflow-changed.outputs.skip != 'true'
+        if: steps.should-skip.outputs.skip != 'true'
         id: claude-review
         uses: anthropics/claude-code-action@426380f01bad0a17200865605a85cb28926dccbf # v1.0.9
         with:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -29,10 +29,42 @@ jobs:
         language: [javascript-typescript]
 
     steps:
+      # Version PRs only modify package.json, CHANGELOG.md, and .changeset files
+      # No code changes to analyze - skip expensive CodeQL analysis
+      # Note: Scheduled runs always run the full analysis
+      - name: Check for Version PR
+        id: check-version-pr
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          HEAD_REF: ${{ github.head_ref }}
+          COMMIT_MSG: ${{ github.event.head_commit.message }}
+        run: |
+          # For pull requests: check branch name
+          if [[ "$EVENT_NAME" == "pull_request" ]]; then
+            if [[ "$HEAD_REF" == "changeset-release/main" ]]; then
+              echo "Version PR detected - skipping CodeQL analysis"
+              echo "skip=true" >> $GITHUB_OUTPUT
+              exit 0
+            fi
+          fi
+
+          # For push events: check commit message
+          if [[ "$EVENT_NAME" == "push" ]]; then
+            if [[ "$COMMIT_MSG" == "chore: release packages"* ]]; then
+              echo "Version PR merge detected - skipping CodeQL analysis"
+              echo "skip=true" >> $GITHUB_OUTPUT
+              exit 0
+            fi
+          fi
+
+          echo "skip=false" >> $GITHUB_OUTPUT
+
       - name: Checkout repository
+        if: steps.check-version-pr.outputs.skip != 'true'
         uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
 
       - name: Initialize CodeQL
+        if: steps.check-version-pr.outputs.skip != 'true'
         uses: github/codeql-action/init@fdbfb4d2750291e159f0156def62b853c2798ca2 # v4
         with:
           languages: ${{ matrix.language }}
@@ -40,9 +72,11 @@ jobs:
           queries: security-extended,security-and-quality
 
       - name: Autobuild
+        if: steps.check-version-pr.outputs.skip != 'true'
         uses: github/codeql-action/autobuild@fdbfb4d2750291e159f0156def62b853c2798ca2 # v4
 
       - name: Perform CodeQL Analysis
+        if: steps.check-version-pr.outputs.skip != 'true'
         uses: github/codeql-action/analyze@fdbfb4d2750291e159f0156def62b853c2798ca2 # v4
         with:
           category: "/language:${{matrix.language}}"

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -15,10 +15,26 @@ jobs:
     timeout-minutes: 5
 
     steps:
+      # Version PRs only modify package.json, CHANGELOG.md, and .changeset files
+      # No new dependencies to review - skip expensive analysis
+      - name: Check for Version PR
+        id: check-version-pr
+        env:
+          HEAD_REF: ${{ github.head_ref }}
+        run: |
+          if [[ "$HEAD_REF" == "changeset-release/main" ]]; then
+            echo "Version PR detected - skipping dependency review"
+            echo "skip=true" >> $GITHUB_OUTPUT
+          else
+            echo "skip=false" >> $GITHUB_OUTPUT
+          fi
+
       - name: Checkout
+        if: steps.check-version-pr.outputs.skip != 'true'
         uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
 
       - name: Dependency Review
+        if: steps.check-version-pr.outputs.skip != 'true'
         uses: actions/dependency-review-action@3c4e3dcb1aa7874d2c16be7d79418e9b7efd6261 # v4.8.2
         with:
           # Block PRs introducing high or critical vulnerabilities

--- a/.github/workflows/secrets-scan.yml
+++ b/.github/workflows/secrets-scan.yml
@@ -16,13 +16,44 @@ jobs:
     timeout-minutes: 10
 
     steps:
+      # Version PRs only modify package.json, CHANGELOG.md, and .changeset files
+      # No code changes to scan for secrets - skip expensive scan
+      - name: Check for Version PR
+        id: check-version-pr
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          HEAD_REF: ${{ github.head_ref }}
+          COMMIT_MSG: ${{ github.event.head_commit.message }}
+        run: |
+          # For pull requests: check branch name
+          if [[ "$EVENT_NAME" == "pull_request" ]]; then
+            if [[ "$HEAD_REF" == "changeset-release/main" ]]; then
+              echo "Version PR detected - skipping secrets scan"
+              echo "skip=true" >> $GITHUB_OUTPUT
+              exit 0
+            fi
+          fi
+
+          # For push events: check commit message
+          if [[ "$EVENT_NAME" == "push" ]]; then
+            if [[ "$COMMIT_MSG" == "chore: release packages"* ]]; then
+              echo "Version PR merge detected - skipping secrets scan"
+              echo "skip=true" >> $GITHUB_OUTPUT
+              exit 0
+            fi
+          fi
+
+          echo "skip=false" >> $GITHUB_OUTPUT
+
       - name: Checkout repository
+        if: steps.check-version-pr.outputs.skip != 'true'
         uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
         with:
           # Full history for comprehensive scanning
           fetch-depth: 0
 
       - name: Run Gitleaks
+        if: steps.check-version-pr.outputs.skip != 'true'
         uses: gitleaks/gitleaks-action@ff98106e4c7b2bc287b24eaf42907196329070c7 # v2.3.9
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -29,16 +29,50 @@ jobs:
       image: semgrep/semgrep@sha256:2b10bb6c3502cad7775542283050b632c13bde1cfdfad7f8230859767a58a078
 
     steps:
+      # Version PRs only modify package.json, CHANGELOG.md, and .changeset files
+      # No code changes to scan - skip expensive analysis
+      # Note: Scheduled runs always run the full scan
+      - name: Check for Version PR
+        id: check-version-pr
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          HEAD_REF: ${{ github.head_ref }}
+          COMMIT_MSG: ${{ github.event.head_commit.message }}
+        run: |
+          # For pull requests: check branch name
+          if [ "$EVENT_NAME" = "pull_request" ]; then
+            if [ "$HEAD_REF" = "changeset-release/main" ]; then
+              echo "Version PR detected - skipping semgrep scan"
+              echo "skip=true" >> $GITHUB_OUTPUT
+              exit 0
+            fi
+          fi
+
+          # For push events: check commit message
+          if [ "$EVENT_NAME" = "push" ]; then
+            case "$COMMIT_MSG" in
+              "chore: release packages"*)
+                echo "Version PR merge detected - skipping semgrep scan"
+                echo "skip=true" >> $GITHUB_OUTPUT
+                exit 0
+                ;;
+            esac
+          fi
+
+          echo "skip=false" >> $GITHUB_OUTPUT
+
       - name: Checkout
+        if: steps.check-version-pr.outputs.skip != 'true'
         uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
 
       - name: Run Semgrep
+        if: steps.check-version-pr.outputs.skip != 'true'
         # Report findings to GitHub Security tab without blocking builds
         # Findings should be triaged and addressed, not auto-blocked
         run: semgrep scan --config auto --sarif --output semgrep.sarif .
 
       - name: Upload SARIF results
         uses: github/codeql-action/upload-sarif@fdbfb4d2750291e159f0156def62b853c2798ca2 # v4
-        if: always()
+        if: steps.check-version-pr.outputs.skip != 'true'
         with:
           sarif_file: semgrep.sarif


### PR DESCRIPTION
## Summary
- Add Version PR detection to secrets-scan, dependency-review, semgrep, codeql, and claude-code-review workflows
- Version PRs (from changesets) only modify version/changelog files - no actual code to scan
- Jobs still run but exit early with success, satisfying required check requirements
- Complements the CI workflow changes from PR #281

## Changes
Each workflow now detects Version PRs via two methods:
1. **Pull request events**: Check if branch is `changeset-release/main`
2. **Push events**: Check if commit message starts with `chore: release packages`

Workflows updated:
- **secrets-scan.yml**: Skips Gitleaks scan
- **dependency-review.yml**: Skips dependency analysis  
- **semgrep.yml**: Skips security scan (scheduled runs still execute)
- **codeql.yml**: Skips CodeQL analysis (scheduled runs still execute)
- **claude-code-review.yml**: Skips AI review

**Security fix**: Uses environment variables for GitHub context data (`github.head_ref`, `github.event.head_commit.message`) to prevent command injection vulnerabilities, as flagged by Semgrep.

This allows Version PRs to merge quickly (~30s) while still satisfying all required checks.

## Test plan
- [ ] Verify this PR's workflows complete successfully (Semgrep security findings resolved)
- [ ] Close and re-open the pending Version PR to trigger new workflow runs
- [ ] Confirm all required checks pass quickly for the Version PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)