### PR TITLE
docs: remove incorrect thin API route layer guidance

### DIFF
--- a/apps/docs/src/content/docs/frameworks/nextjs-app-router/getting-started.mdx
+++ b/apps/docs/src/content/docs/frameworks/nextjs-app-router/getting-started.mdx
@@ -22,9 +22,9 @@ npm install -D @playwright/test @scenarist/playwright-helpers
 
 <Aside type="note" title="Testing Apps with Database Access?">
 
-If your Next.js app uses **direct database access** (PostgreSQL, MongoDB, Prisma, etc.) instead of HTTP APIs, Scenarist cannot mock those calls directly. However, you can make your app testable by adding a thin API route layer.
+If your Next.js app uses **direct database access** (PostgreSQL, MongoDB, Prisma, etc.) instead of HTTP APIs, Scenarist cannot mock those database calls. Use **Testcontainers** for real database testing combined with Scenarist for external API mocking.
 
-**[→ Read the Database Testing Guide](/guides/testing-database-apps)** to learn how to test database-heavy Next.js applications with Scenarist.
+**[→ Read the Database Testing Guide](/guides/testing-database-apps)** to learn the recommended testing strategy for apps with database access.
 
 **[→ See what Scenarist can and cannot mock](/getting-started/why-scenarist#what-cannot-be-intercepted)**
 
@@ -333,5 +333,5 @@ You don't need `if (scenarist)` checks - just spread the helper directly into yo
 ## Next Steps
 
 - **[Example App on GitHub →](https://github.com/citypaul/scenarist/tree/main/apps/nextjs-app-router-example)** - Clone and run the complete working example
-- **[Testing Database Apps →](/guides/testing-database-apps)** - Learn how to test Next.js apps with database access using API route abstraction
+- **[Testing Database Apps →](/guides/testing-database-apps)** - Learn how to test Next.js apps that use both databases and external APIs
 - **[Architecture →](/concepts/architecture)** - Learn how Scenarist works under the hood

--- a/apps/docs/src/content/docs/frameworks/nextjs-pages-router/getting-started.mdx
+++ b/apps/docs/src/content/docs/frameworks/nextjs-pages-router/getting-started.mdx
@@ -22,9 +22,9 @@ npm install -D @playwright/test @scenarist/playwright-helpers
 
 <Aside type="note" title="Testing Apps with Database Access?">
 
-If your Next.js app uses **direct database access** (PostgreSQL, MongoDB, Prisma, etc.) instead of HTTP APIs, Scenarist cannot mock those calls directly. However, you can make your app testable by adding a thin API route layer.
+If your Next.js app uses **direct database access** (PostgreSQL, MongoDB, Prisma, etc.) instead of HTTP APIs, Scenarist cannot mock those database calls. Use **Testcontainers** for real database testing combined with Scenarist for external API mocking.
 
-**[→ Read the Database Testing Guide](/guides/testing-database-apps)** to learn how to test database-heavy Next.js applications with Scenarist.
+**[→ Read the Database Testing Guide](/guides/testing-database-apps)** to learn the recommended testing strategy for apps with database access.
 
 **[→ See what Scenarist can and cannot mock](/getting-started/why-scenarist#what-cannot-be-intercepted)**
 
@@ -371,5 +371,5 @@ You don't need `if (scenarist)` checks - just spread the helper directly into yo
 ## Next Steps
 
 - **[Example App on GitHub →](https://github.com/citypaul/scenarist/tree/main/apps/nextjs-pages-router-example)** - Clone and run the complete working example
-- **[Testing Database Apps →](/guides/testing-database-apps)** - Learn how to test Next.js apps with database access using API route abstraction
+- **[Testing Database Apps →](/guides/testing-database-apps)** - Learn how to test Next.js apps that use both databases and external APIs
 - **[Architecture →](/concepts/architecture)** - Learn how Scenarist works under the hood


### PR DESCRIPTION
## Summary

- Removed incorrect claim that apps with database access can be made testable by adding a "thin API route layer"
- Updated both Next.js App Router and Pages Router getting started guides
- Updated link descriptions to accurately reflect database testing guide content

## Background

The getting started guides incorrectly suggested that database-heavy apps could be made testable with Scenarist by wrapping database calls in API routes. This approach was previously attempted and documented as **architecturally flawed** in the database testing guide.

**Why it doesn't work:**
- MSW intercepts at the network level
- Internal Next.js API route calls don't traverse the network stack  
- Server Components calling `fetch('http://localhost:3000/api/...')` don't make actual network requests
- Next.js handles routing internally without hitting the network

**The correct approach:**
- Use **Testcontainers** for real database testing
- Use **Scenarist** for external HTTP API mocking
- The database testing guide already correctly explains this hybrid approach

## Changes

| File | Change |
|------|--------|
| `frameworks/nextjs-app-router/getting-started.mdx` | Removed "thin API route layer" suggestion, updated link text |
| `frameworks/nextjs-pages-router/getting-started.mdx` | Removed "thin API route layer" suggestion, updated link text |

## Test plan

- [ ] Documentation renders correctly on the docs site
- [ ] Links point to the correct pages
- [ ] No other documentation references the incorrect approach

🤖 Generated with [Claude Code](https://claude.com/claude-code)