### PR TITLE
docs: document Next.js singleton pattern and add cross-links

### DIFF
--- a/apps/docs/src/content/docs/comparison/index.mdx
+++ b/apps/docs/src/content/docs/comparison/index.mdx
@@ -32,6 +32,18 @@ Scenarist is built on [MSW](https://mswjs.io/) and adds a complete scenario mana
   </Card>
 </CardGrid>
 
+### Framework Adapters Solve Real Problems
+
+Scenarist's adapters aren't thin wrappers—they solve framework-specific challenges that would otherwise require significant boilerplate:
+
+**Next.js Adapter:**
+- **[Module duplication protection](https://github.com/vercel/next.js/discussions/68572)** — Next.js dev mode and Turbopack can load modules multiple times, causing `[MSW] Multiple handlers with the same URL` errors and memory leaks. Scenarist's built-in singleton pattern (`global.__scenarist_instance`) handles this automatically.
+- **App Router private folders** — Folders starting with `_` are private in App Router. Scenarist documents the `%5F` URL encoding workaround for `/__scenario__` endpoints.
+- **Pages + App Router isolation** — Separate global state keys enable gradual migration without scenario cross-contamination.
+- **Conditional exports** — Zero MSW code in production bundles via automatic tree-shaking.
+
+Without these solutions, you'd need to understand Next.js internals and implement the `globalThis` singleton pattern yourself—Scenarist handles it with a simple `export const`.
+
 ### The Parallel Testing Advantage
 
 Most mock tools require separate instances for parallel test isolation. Scenarist uses header-based routing instead:
@@ -111,12 +123,12 @@ Scenarist is built on top of [Mock Service Worker (MSW)](https://mswjs.io/)—th
 - Proven reliability and active maintenance
 
 **What Scenarist adds:**
-- **Test ID isolation** — Parallel tests with different scenarios
-- **Runtime switching** — Change scenarios without restart
-- **First-class Playwright support** — Dedicated fixtures with type-safe scenario switching and automatic test ID isolation
-- **Response sequences** — Built-in support for polling, retry flows, state machines
-- **Stateful mocks** — Capture values from requests, inject into responses (state isolated per test ID)
-- **Advanced matching** — Body, headers, query params, regex patterns
+- **[Test ID isolation](/testing/parallel-testing)** — Parallel tests with different scenarios
+- **[Runtime switching](/concepts/how-it-works#runtime-scenario-switching)** — Change scenarios without restart
+- **[First-class Playwright support](/testing/playwright-integration)** — Dedicated fixtures with type-safe scenario switching and automatic test ID isolation
+- **[Response sequences](/concepts/dynamic-responses#response-sequences)** — Built-in support for polling, retry flows, state machines
+- **[Stateful mocks](/concepts/dynamic-responses#stateful-mocks)** — Capture values from requests, inject into responses (state isolated per test ID)
+- **[Advanced matching](/concepts/dynamic-responses#request-matching)** — Body, headers, query params, regex patterns
 - **Framework adapters** — Express, Next.js integration out of the box
 
 If you need low-level control or use MSW for non-testing purposes (API development, storybook), use MSW directly. If you need scenario management for testing, Scenarist handles that layer.

--- a/apps/docs/src/content/docs/comparison/vs-wiremock.mdx
+++ b/apps/docs/src/content/docs/comparison/vs-wiremock.mdx
@@ -190,7 +190,7 @@ test('retry after failure', async ({ page }) => {
 
 ### First-Class Playwright Integration
 
-Scenarist provides dedicated Playwright fixtures that handle test ID generation, scenario switching, and header propagation automatically.
+Scenarist provides dedicated [Playwright fixtures](/testing/playwright-integration) that handle test ID generation, scenario switching, and header propagation automatically.
 
 <Tabs>
   <TabItem label="Scenarist">
@@ -259,7 +259,7 @@ test('premium user checkout', async ({ page }) => {
   </TabItem>
 </Tabs>
 
-**Trade-off:** Scenarist's Playwright helpers provide automatic test ID isolation—each test gets its own scenario state without manual header management. WireMock requires manual HTTP calls and careful state management. Future Scenarist releases plan to add similar first-class support for Cypress.
+**Trade-off:** Scenarist's [Playwright helpers](/testing/playwright-integration) provide automatic test ID isolation—each test gets its own scenario state without manual header management. WireMock requires manual HTTP calls and careful state management. Future Scenarist releases plan to add similar first-class support for Cypress.
 
 ### Dynamic Response Features
 

--- a/apps/docs/src/content/docs/comparison/with-msw.mdx
+++ b/apps/docs/src/content/docs/comparison/with-msw.mdx
@@ -41,7 +41,7 @@ Scenarist is built on top of [Mock Service Worker (MSW)](https://mswjs.io/)—we
 - Complete test ID isolation (scenarios, sequences, and captured state—all per test ID)
 - Declarative scenario definitions (inspectable, composable, type-safe)
 - Framework adapters (Express, Next.js integration out of the box)
-- First-class Playwright fixtures (automatic test ID handling)
+- [First-class Playwright fixtures](/testing/playwright-integration) (automatic test ID handling)
 
 *Note: MSW v2.2.0+ added `server.boundary()` for isolating handler registrations in concurrent tests. Scenarist's test ID system provides broader isolation—including sequence positions and captured state—and works with any test framework.*
 

--- a/apps/docs/src/content/docs/concepts/how-it-works.md
+++ b/apps/docs/src/content/docs/concepts/how-it-works.md
@@ -163,7 +163,7 @@ export const scenarios = {
 } as const satisfies ScenaristScenarios;
 ```
 
-**Step 3: Set up Playwright fixtures** (one-time setup)
+**Step 3: [Set up Playwright fixtures](/testing/playwright-integration)** (one-time setup)
 
 ```typescript
 // tests/fixtures.ts
@@ -200,7 +200,7 @@ test("premium users access advanced features", async ({
 
 1. Framework adapter integrates Scenarist into your Next.js app
 2. Scenarios define how external APIs behave
-3. Playwright fixtures create type-safe test helpers with scenario autocomplete
+3. [Playwright fixtures](/testing/playwright-integration) create type-safe test helpers with scenario autocomplete
 4. Tests import from fixtures (not @playwright/test directly)
 5. Test switches to scenario and makes real HTTP requests
 6. Your backend code executes with production behavior

--- a/apps/docs/src/content/docs/getting-started/installation.md
+++ b/apps/docs/src/content/docs/getting-started/installation.md
@@ -133,7 +133,7 @@ yarn add @scenarist/express-adapter msw
 yarn add -D @scenarist/playwright-helpers @playwright/test
 ```
 
-Use Playwright helpers when you need to test user interactions through a browser (clicks, form submissions, visual verification).
+Use [Playwright helpers](/testing/playwright-integration) when you need to test user interactions through a browser (clicks, form submissions, visual verification).
 
 **Peer dependencies:** `express@^4.18.0 || ^5.0.0`, `msw@^2.0.0`
 

--- a/apps/docs/src/content/docs/getting-started/why-scenarist.mdx
+++ b/apps/docs/src/content/docs/getting-started/why-scenarist.mdx
@@ -43,7 +43,7 @@ This creates a testing challenge:
 
 **Between these approaches lies a gap:** Testing server-side HTTP behavior with different external API responses, without browser overhead or extensive framework mocking.
 
-**Scenarist fills this gap** by testing your server-side HTTP layer with mocked external APIs. Your code—Server Components, loaders, middleware, business logic—executes normally. Only HTTP requests (fetch, axios, etc.) are intercepted, returning scenario-defined responses based on test ID. This enables testing full user journeys through the browser using Playwright helpers, with each test isolated and running in parallel.
+**Scenarist fills this gap** by testing your server-side HTTP layer with mocked external APIs. Your code—Server Components, loaders, middleware, business logic—executes normally. Only HTTP requests (fetch, axios, etc.) are intercepted, returning scenario-defined responses based on test ID. This enables testing full user journeys through the browser using [Playwright helpers](/testing/playwright-integration), with each test isolated and running in parallel.
 
 **Test extensive external API scenarios in parallel** without expensive cloud API calls or complex test infrastructure.
 

--- a/apps/docs/src/content/docs/reference/api-endpoints.mdx
+++ b/apps/docs/src/content/docs/reference/api-endpoints.mdx
@@ -91,7 +91,7 @@ x-scenarist-test-id: <test-id>
 
 ### Example Usage
 
-**With Playwright helpers:**
+**With [Playwright helpers](/testing/playwright-integration):**
 ```typescript
 import { test } from '@scenarist/playwright-helpers';
 

--- a/apps/docs/src/content/docs/reference/ephemeral-endpoints.mdx
+++ b/apps/docs/src/content/docs/reference/ephemeral-endpoints.mdx
@@ -164,7 +164,7 @@ import { SCENARIST_TEST_ID_HEADER } from '@scenarist/express-adapter';
 
 ### Automatic Test ID Propagation
 
-Playwright helpers automatically include the test ID header:
+[Playwright helpers](/testing/playwright-integration) automatically include the test ID header:
 
 ```typescript
 // tests/fixtures.ts - Set up once

--- a/apps/docs/src/content/docs/roadmap.mdx
+++ b/apps/docs/src/content/docs/roadmap.mdx
@@ -134,12 +134,12 @@ Scenarist is open source. If you're interested in contributing to any of these f
 
 While we work on future features, Scenarist already provides:
 
-- **Test ID isolation** — Parallel tests with different scenarios
-- **Runtime switching** — Change scenarios mid-test
-- **First-class Playwright fixtures** — Type-safe scenario management
-- **Response sequences** — Polling, retry flows, state machines
-- **Stateful mocks** — Capture and inject request data
-- **Advanced matching** — Body, headers, query, regex patterns
+- **[Test ID isolation](/testing/parallel-testing)** — Parallel tests with different scenarios
+- **[Runtime switching](/concepts/how-it-works#runtime-scenario-switching)** — Change scenarios mid-test
+- **[First-class Playwright fixtures](/testing/playwright-integration)** — Type-safe scenario management
+- **[Response sequences](/concepts/dynamic-responses#response-sequences)** — Polling, retry flows, state machines
+- **[Stateful mocks](/concepts/dynamic-responses#stateful-mocks)** — Capture and inject request data
+- **[Advanced matching](/concepts/dynamic-responses#request-matching)** — Body, headers, query, regex patterns
 - **Production safety** — Zero overhead in production bundles
 
 [Get started with Scenarist →](/getting-started/quick-start)


### PR DESCRIPTION
## Summary

This PR adds documentation for Scenarist's Next.js singleton pattern advantage and improves cross-linking throughout the documentation.

### Next.js Singleton Pattern Documentation

Added a new "Framework Adapters Solve Real Problems" section to the Tool Comparison page explaining:

- **Module duplication protection** - Next.js dev mode and Turbopack can load modules multiple times, causing `[MSW] Multiple handlers with the same URL` errors. Scenarist's built-in singleton pattern (`global.__scenarist_instance`) handles this automatically.
- **App Router private folders** - Documents the `%5F` URL encoding workaround for `/__scenario__` endpoints
- **Pages + App Router isolation** - Separate global state keys enable gradual migration without scenario cross-contamination
- **Conditional exports** - Zero MSW code in production bundles via automatic tree-shaking

Links to the relevant Next.js GitHub discussion: https://github.com/vercel/next.js/discussions/68572

### Playwright Helpers Cross-Links

Added links to `/testing/playwright-integration` where Playwright helpers are mentioned:
- comparison/with-msw.mdx
- comparison/vs-wiremock.mdx (2 locations)
- getting-started/why-scenarist.mdx
- getting-started/installation.md
- concepts/how-it-works.md (2 locations)
- reference/api-endpoints.mdx
- reference/ephemeral-endpoints.mdx
- roadmap.mdx

### Feature Cross-Links

Added links for all current capabilities in roadmap.mdx and comparison/index.mdx:
- Test ID isolation → /testing/parallel-testing
- Runtime switching → /concepts/how-it-works#runtime-scenario-switching
- Response sequences → /concepts/dynamic-responses#response-sequences
- Stateful mocks → /concepts/dynamic-responses#stateful-mocks
- Advanced matching → /concepts/dynamic-responses#request-matching

## Test plan

- [x] Documentation builds successfully (`pnpm --filter=@scenarist/docs build`)
- [x] All new links are valid internal documentation paths
- [ ] Visual review of new sections in browser

🤖 Generated with [Claude Code](https://claude.com/claude-code)