### PR TITLE
docs: fix Express createScenarist() examples to use async/await

### DIFF
--- a/.changeset/fix-express-async-docs.md
+++ b/.changeset/fix-express-async-docs.md
@@ -1,0 +1,14 @@
+---
+"@scenarist/express-adapter": patch
+---
+
+docs: fix Express createScenarist() documentation to show async/await pattern
+
+The `createScenarist()` function in the Express adapter returns a `Promise<ExpressScenarist<T> | undefined>`, but documentation examples incorrectly showed synchronous usage without `await`. This caused TypeScript errors when users followed the documentation.
+
+**Changes:**
+
+- Updated all Express documentation to use `await createScenarist(...)`
+- Added factory function pattern for test setup (avoiding `let` variables)
+- Fixed examples in README.md, getting-started.mdx, example-app.mdx, and related docs
+- Added explicit notes that createScenarist is async where relevant

--- a/apps/docs/src/content/docs/comparison/vs-testcontainers.mdx
+++ b/apps/docs/src/content/docs/comparison/vs-testcontainers.mdx
@@ -3,8 +3,8 @@ title: Scenarist vs Testcontainers
 description: Mocking external APIs vs running real containerized services - complementary approaches
 ---
 
-import { Tabs, TabItem, Card, CardGrid } from '@astrojs/starlight/components';
-import WhatScenaristOffers from '../../../components/comparison/WhatScenaristOffers.astro';
+import { Tabs, TabItem, Card, CardGrid } from "@astrojs/starlight/components";
+import WhatScenaristOffers from "../../../components/comparison/WhatScenaristOffers.astro";
 
 [Testcontainers](https://testcontainers.com/) runs real services in Docker containers for testing—PostgreSQL, Redis, Kafka, and more. Scenarist mocks HTTP APIs. These tools solve **different problems** and are often **complementary** rather than competing.
 
@@ -36,14 +36,14 @@ import WhatScenaristOffers from '../../../components/comparison/WhatScenaristOff
 └─────────────────────────────────────────────────────────────────┘
 ```
 
-| Aspect | Testcontainers | Scenarist |
-|--------|----------------|-----------|
-| **Purpose** | Run real services | Mock HTTP APIs |
-| **Use case** | Databases, message queues | Third-party APIs |
-| **What runs** | Actual software in Docker | Your app with mocked responses |
-| **Fidelity** | Real behavior | Controlled scenarios |
-| **Startup time** | Seconds to minutes | Instant |
-| **Resource usage** | Container per service | In-process |
+| Aspect             | Testcontainers            | Scenarist                      |
+| ------------------ | ------------------------- | ------------------------------ |
+| **Purpose**        | Run real services         | Mock HTTP APIs                 |
+| **Use case**       | Databases, message queues | Third-party APIs               |
+| **What runs**      | Actual software in Docker | Your app with mocked responses |
+| **Fidelity**       | Real behavior             | Controlled scenarios           |
+| **Startup time**   | Seconds to minutes        | Instant                        |
+| **Resource usage** | Container per service     | In-process                     |
 
 ## When Each Tool Applies
 
@@ -51,7 +51,8 @@ import WhatScenaristOffers from '../../../components/comparison/WhatScenaristOff
 
 <CardGrid>
   <Card title="Database testing" icon="seti:db">
-    PostgreSQL, MySQL, MongoDB, Redis. Test real queries, migrations, transactions.
+    PostgreSQL, MySQL, MongoDB, Redis. Test real queries, migrations,
+    transactions.
   </Card>
   <Card title="Message queues" icon="seti:shell">
     Kafka, RabbitMQ, SQS (LocalStack). Test actual message processing.
@@ -68,7 +69,8 @@ import WhatScenaristOffers from '../../../components/comparison/WhatScenaristOff
 
 <CardGrid>
   <Card title="External HTTP APIs" icon="seti:json">
-    Stripe, Auth0, SendGrid, Twilio. APIs you don't control and can't run locally.
+    Stripe, Auth0, SendGrid, Twilio. APIs you don't control and can't run
+    locally.
   </Card>
   <Card title="Error scenarios" icon="warning">
     Test how your app handles API timeouts, rate limits, specific error codes.
@@ -89,59 +91,61 @@ A typical application might use **both** tools:
 // test-setup.ts
 
 // Testcontainers for your database
-import { PostgreSqlContainer } from '@testcontainers/postgresql';
+import { PostgreSqlContainer } from "@testcontainers/postgresql";
 
-const postgres = await new PostgreSqlContainer()
-  .withDatabase('testdb')
-  .start();
+const postgres = await new PostgreSqlContainer().withDatabase("testdb").start();
 
 // Your app connects to real PostgreSQL in Docker
 process.env.DATABASE_URL = postgres.getConnectionUri();
 
 // Scenarist for external APIs
 // Stripe, SendGrid, etc. are mocked - they don't have containers
-export const scenarist = createScenarist({
+// Note: createScenarist is async - use await
+export const scenarist = await createScenarist({
   enabled: true,
   scenarios: {
     default: {
       mocks: [
         {
-          url: 'https://api.stripe.com/v1/charges',
-          method: 'POST',
-          response: { status: 200, body: { id: 'ch_123' } }
+          url: "https://api.stripe.com/v1/charges",
+          method: "POST",
+          response: { status: 200, body: { id: "ch_123" } },
         },
         {
-          url: 'https://api.sendgrid.com/v3/mail/send',
-          method: 'POST',
-          response: { status: 202 }
-        }
-      ]
-    }
-  }
+          url: "https://api.sendgrid.com/v3/mail/send",
+          method: "POST",
+          response: { status: 202 },
+        },
+      ],
+    },
+  },
 });
 ```
 
 ```typescript
 // checkout.spec.ts
-test('creates order and sends confirmation', async ({ page, switchScenario }) => {
+test("creates order and sends confirmation", async ({
+  page,
+  switchScenario,
+}) => {
   // Database operations use real PostgreSQL (Testcontainers)
   // Stripe payment uses mocked API (Scenarist)
   // SendGrid email uses mocked API (Scenarist)
 
-  await switchScenario(page, 'payment-success');
+  await switchScenario(page, "payment-success");
 
-  await page.goto('/checkout');
-  await page.fill('[name="card"]', '4242424242424242');
-  await page.click('#submit');
+  await page.goto("/checkout");
+  await page.fill('[name="card"]', "4242424242424242");
+  await page.click("#submit");
 
   // Real database write happened
   // Mocked Stripe returned success
   // Mocked SendGrid accepted email
-  await expect(page.locator('.success')).toBeVisible();
+  await expect(page.locator(".success")).toBeVisible();
 
   // Verify database state (real PostgreSQL)
-  const order = await db.query('SELECT * FROM orders WHERE id = $1', [orderId]);
-  expect(order.status).toBe('completed');
+  const order = await db.query("SELECT * FROM orders WHERE id = $1", [orderId]);
+  expect(order.status).toBe("completed");
 });
 ```
 
@@ -149,19 +153,19 @@ test('creates order and sends confirmation', async ({ page, switchScenario }) =>
 
 **Yes, but with more complexity.** Testcontainers has modules for HTTP mock servers:
 
-| Module | Package | Status |
-|--------|---------|--------|
-| MockServer | `@testcontainers/mockserver` | Official |
-| WireMock | `@wiremock/wiremock-testcontainers-node` | [Official Partner](https://testcontainers.com/modules/wiremock/) |
+| Module     | Package                                  | Status                                                           |
+| ---------- | ---------------------------------------- | ---------------------------------------------------------------- |
+| MockServer | `@testcontainers/mockserver`             | Official                                                         |
+| WireMock   | `@wiremock/wiremock-testcontainers-node` | [Official Partner](https://testcontainers.com/modules/wiremock/) |
 
 ```typescript
 // Testcontainers with WireMock for HTTP mocking
-import { WireMockContainer } from '@wiremock/wiremock-testcontainers-node';
+import { WireMockContainer } from "@wiremock/wiremock-testcontainers-node";
 
 const container = await new WireMockContainer()
   .withMapping({
-    request: { method: 'GET', urlPath: '/v1/products' },
-    response: { status: 200, jsonBody: { products: [] } }
+    request: { method: "GET", urlPath: "/v1/products" },
+    response: { status: 200, jsonBody: { products: [] } },
   })
   .start();
 
@@ -171,20 +175,22 @@ process.env.STRIPE_API_URL = container.getBaseUrl();
 
 **Trade-offs vs Scenarist:**
 
-| Factor | Testcontainers + WireMock | Scenarist |
-|--------|---------------------------|-----------|
-| Setup | Docker + container management | npm install |
-| Startup time | Seconds (container spin-up) | Instant (in-process) |
-| Test isolation | Per-container (heavier) | Per-header (lightweight) |
-| Runtime switching | Admin API | Single API call |
-| Network config | Required (proxy/env vars) | None (in-process) |
+| Factor            | Testcontainers + WireMock     | Scenarist                |
+| ----------------- | ----------------------------- | ------------------------ |
+| Setup             | Docker + container management | npm install              |
+| Startup time      | Seconds (container spin-up)   | Instant (in-process)     |
+| Test isolation    | Per-container (heavier)       | Per-header (lightweight) |
+| Runtime switching | Admin API                     | Single API call          |
+| Network config    | Required (proxy/env vars)     | None (in-process)        |
 
 **When HTTP mocking via Testcontainers makes sense:**
+
 - You're already heavily invested in Testcontainers
 - You want identical mocking approach to your Java/Go services
 - You need WireMock's specific features (recording, contract testing)
 
 **When Scenarist is simpler:**
+
 - You want the lightest possible setup
 - You're already in a Node.js/TypeScript environment
 - You value instant test startup over container isolation
@@ -211,7 +217,8 @@ Mocking databases is possible but loses fidelity:
 // - Transaction behavior
 // - Migration testing
 // - Performance characteristics
-```
+
+````
   </TabItem>
   <TabItem label="Real Database (Better)">
 ```typescript
@@ -227,28 +234,30 @@ const result = await db.query(`
 
 // Real constraints, real behavior
 // Your ORM/query builder works exactly like production
-```
+````
+
   </TabItem>
 </Tabs>
 
 **Rule of thumb:**
+
 - **Use Testcontainers** for services you own or can run locally
 - **Use Scenarist** for services you don't control (third-party APIs)
 
 ## Comparison Summary
 
-| Factor | Testcontainers | Scenarist |
-|--------|----------------|-----------|
-| Databases | ✓ Best choice | Not recommended |
-| Message queues | ✓ Best choice | Not recommended |
-| HTTP API mocking | ✓ Via WireMock/MockServer | ✓ Built-in |
-| Setup complexity | Docker + containers | npm install |
-| Startup time | Seconds (containers) | ✓ Instant |
-| Resource usage | Higher (containers) | ✓ Minimal |
-| Fidelity | ✓ Real behavior | Controlled |
-| Parallel isolation | Per-container | ✓ Per-header (lightweight) |
-| Runtime switching | Admin API | ✓ Single API call |
-| Playwright fixtures | Manual setup | ✓ First-class support |
+| Factor              | Testcontainers            | Scenarist                  |
+| ------------------- | ------------------------- | -------------------------- |
+| Databases           | ✓ Best choice             | Not recommended            |
+| Message queues      | ✓ Best choice             | Not recommended            |
+| HTTP API mocking    | ✓ Via WireMock/MockServer | ✓ Built-in                 |
+| Setup complexity    | Docker + containers       | npm install                |
+| Startup time        | Seconds (containers)      | ✓ Instant                  |
+| Resource usage      | Higher (containers)       | ✓ Minimal                  |
+| Fidelity            | ✓ Real behavior           | Controlled                 |
+| Parallel isolation  | Per-container             | ✓ Per-header (lightweight) |
+| Runtime switching   | Admin API                 | ✓ Single API call          |
+| Playwright fixtures | Manual setup              | ✓ First-class support      |
 
 ## Hybrid Architecture
 
@@ -282,6 +291,7 @@ For comprehensive testing, use both:
 ```
 
 **This hybrid approach gives you:**
+
 - Real database behavior (Testcontainers)
 - Controlled external API scenarios (Scenarist)
 - Comprehensive test coverage

--- a/apps/docs/src/content/docs/comparison/vs-wiremock.mdx
+++ b/apps/docs/src/content/docs/comparison/vs-wiremock.mdx
@@ -3,8 +3,8 @@ title: Scenarist vs WireMock
 description: Compare in-process network mocking with server-based mock servers for API testing
 ---
 
-import { Tabs, TabItem, Card, CardGrid } from '@astrojs/starlight/components';
-import WhatScenaristOffers from '../../../components/comparison/WhatScenaristOffers.astro';
+import { Tabs, TabItem, Card, CardGrid } from "@astrojs/starlight/components";
+import WhatScenaristOffers from "../../../components/comparison/WhatScenaristOffers.astro";
 
 [WireMock](https://wiremock.org/) is a mature, widely-adopted mock server for simulating HTTP APIs. It runs as a standalone Java process and can be used from any language. Scenarist takes a different approach—intercepting requests within your Node.js process using MSW.
 
@@ -12,18 +12,18 @@ import WhatScenaristOffers from '../../../components/comparison/WhatScenaristOff
 
 ## At a Glance
 
-| Aspect | Scenarist | WireMock |
-|--------|-----------|----------|
-| **Architecture** | In-process (MSW) | Standalone server |
-| **Language** | TypeScript/JavaScript | Language-agnostic (Node.js via [wiremock](https://www.npmjs.com/package/wiremock) CLI or [wiremock-captain](https://www.npmjs.com/package/wiremock-captain) client) |
-| **Test isolation** | Per-test via header | Per-server instance or Scenarios |
-| **Runtime switching** | Yes (single API call) | Yes (Admin API) |
-| **Setup** | npm install | JAR, Docker, or npm + network configuration |
-| **Test framework integration** | First-class Playwright fixtures | Generic HTTP API |
-| **Response sequences** | Built-in (polling, state machines) | Built-in (Scenarios feature) |
-| **Stateful mocks** | Built-in capture/inject per test ID | Built-in state machine |
-| **Recording** | Not supported | Built-in record/playback |
-| **Templating** | Template strings | Handlebars templating |
+| Aspect                         | Scenarist                           | WireMock                                                                                                                                                            |
+| ------------------------------ | ----------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Architecture**               | In-process (MSW)                    | Standalone server                                                                                                                                                   |
+| **Language**                   | TypeScript/JavaScript               | Language-agnostic (Node.js via [wiremock](https://www.npmjs.com/package/wiremock) CLI or [wiremock-captain](https://www.npmjs.com/package/wiremock-captain) client) |
+| **Test isolation**             | Per-test via header                 | Per-server instance or Scenarios                                                                                                                                    |
+| **Runtime switching**          | Yes (single API call)               | Yes (Admin API)                                                                                                                                                     |
+| **Setup**                      | npm install                         | JAR, Docker, or npm + network configuration                                                                                                                         |
+| **Test framework integration** | First-class Playwright fixtures     | Generic HTTP API                                                                                                                                                    |
+| **Response sequences**         | Built-in (polling, state machines)  | Built-in (Scenarios feature)                                                                                                                                        |
+| **Stateful mocks**             | Built-in capture/inject per test ID | Built-in state machine                                                                                                                                              |
+| **Recording**                  | Not supported                       | Built-in record/playback                                                                                                                                            |
+| **Templating**                 | Template strings                    | Handlebars templating                                                                                                                                               |
 
 ## Key Differences
 
@@ -35,23 +35,25 @@ import WhatScenaristOffers from '../../../components/comparison/WhatScenaristOff
 // Mocks run in the same process as your app
 import { createScenarist } from '@scenarist/express-adapter';
 
-export const scenarist = createScenarist({
-  enabled: process.env.NODE_ENV === 'test',
-  scenarios: {
-    default: {
-      mocks: [{
-        url: 'https://api.stripe.com/v1/charges',
-        method: 'POST',
-        response: { status: 200, body: { id: 'ch_123' } }
-      }]
-    }
-  }
+// Note: createScenarist is async - use await
+export const scenarist = await createScenarist({
+enabled: process.env.NODE_ENV === 'test',
+scenarios: {
+default: {
+mocks: [{
+url: 'https://api.stripe.com/v1/charges',
+method: 'POST',
+response: { status: 200, body: { id: 'ch_123' } }
+}]
+}
+}
 });
 
 // No external process to manage
 // No network latency between your app and mocks
 // Debugging in the same process
-```
+
+````
   </TabItem>
   <TabItem label="WireMock">
 ```java
@@ -72,7 +74,8 @@ export const scenarist = createScenarist({
 
 // Your app calls WireMock instead of real API
 // STRIPE_API_URL=http://localhost:8080 npm test
-```
+````
+
   </TabItem>
 </Tabs>
 
@@ -92,15 +95,16 @@ test('payment success', async ({ page, switchScenario }) => {
 });
 
 test('payment declined', async ({ page, switchScenario }) => {
-  // Same app, same time, different scenario
-  await switchScenario(page, 'payment-declined');
-  await page.goto('/checkout');
-  await expect(page.locator('.error')).toBeVisible();
+// Same app, same time, different scenario
+await switchScenario(page, 'payment-declined');
+await page.goto('/checkout');
+await expect(page.locator('.error')).toBeVisible();
 });
 
 // Both tests run in parallel against ONE server
 // Test ID header routes to correct scenario
-```
+
+````
   </TabItem>
   <TabItem label="WireMock">
 ```typescript
@@ -125,7 +129,8 @@ beforeEach(async () => {
 
 // Parallel tests require multiple WireMock instances
 // Or sophisticated scenario management
-```
+````
+
   </TabItem>
 </Tabs>
 
@@ -144,12 +149,13 @@ test('retry after failure', async ({ page, switchScenario }) => {
   await page.click('[data-testid="submit"]');
   await expect(page.locator('.retry-button')).toBeVisible();
 
-  // Switch to success - same test, same page
-  await switchScenario(page, 'payment-success');
-  await page.click('.retry-button');
-  await expect(page.locator('.success')).toBeVisible();
+// Switch to success - same test, same page
+await switchScenario(page, 'payment-success');
+await page.click('.retry-button');
+await expect(page.locator('.success')).toBeVisible();
 });
-```
+
+````
   </TabItem>
   <TabItem label="WireMock">
 ```typescript
@@ -182,7 +188,8 @@ test('retry after failure', async ({ page }) => {
 
   await page.click('.retry-button');
 });
-```
+````
+
   </TabItem>
 </Tabs>
 
@@ -206,21 +213,22 @@ export { expect };
 import { test, expect } from './fixtures';
 
 test('premium user checkout', async ({ page, switchScenario }) => {
-  // Type-safe scenario ID with autocomplete
-  await switchScenario(page, 'premium-user');
+// Type-safe scenario ID with autocomplete
+await switchScenario(page, 'premium-user');
 
-  await page.goto('/checkout');
-  await expect(page.locator('.premium-discount')).toBeVisible();
+await page.goto('/checkout');
+await expect(page.locator('.premium-discount')).toBeVisible();
 });
 
 test('payment declined', async ({ page, switchScenario }) => {
-  await switchScenario(page, 'payment-declined');
+await switchScenario(page, 'payment-declined');
 
-  await page.goto('/checkout');
-  await page.click('[data-testid="submit"]');
-  await expect(page.locator('.error-message')).toContainText('declined');
+await page.goto('/checkout');
+await page.click('[data-testid="submit"]');
+await expect(page.locator('.error-message')).toContainText('declined');
 });
-```
+
+````
   </TabItem>
   <TabItem label="WireMock">
 ```typescript
@@ -255,7 +263,8 @@ test('premium user checkout', async ({ page }) => {
     method: 'POST'
   });
 });
-```
+````
+
   </TabItem>
 </Tabs>
 
@@ -286,16 +295,17 @@ Both Scenarist and WireMock support dynamic responses, but with different approa
 
 // Perfect for testing polling UIs
 test('shows job progress', async ({ page, switchScenario }) => {
-  await switchScenario(page, 'job-processing');
-  await page.goto('/jobs/123');
+await switchScenario(page, 'job-processing');
+await page.goto('/jobs/123');
 
-  await expect(page.locator('.status')).toContainText('pending');
-  await page.click('[data-testid="refresh"]');
-  await expect(page.locator('.status')).toContainText('processing');
-  await page.click('[data-testid="refresh"]');
-  await expect(page.locator('.status')).toContainText('complete');
+await expect(page.locator('.status')).toContainText('pending');
+await page.click('[data-testid="refresh"]');
+await expect(page.locator('.status')).toContainText('processing');
+await page.click('[data-testid="refresh"]');
+await expect(page.locator('.status')).toContainText('complete');
 });
-```
+
+````
   </TabItem>
   <TabItem label="WireMock">
 ```java
@@ -325,7 +335,8 @@ stubFor(get(urlEqualTo("/job/123/status"))
   .willReturn(aResponse()
     .withBody("{\"status\": \"complete\", \"result\": \"success\"}")
   ));
-```
+````
+
   </TabItem>
 </Tabs>
 
@@ -355,7 +366,8 @@ stubFor(get(urlEqualTo("/job/123/status"))
 
 // Specificity-based selection - most specific match wins
 // No need to carefully order your mocks
-```
+
+````
   </TabItem>
   <TabItem label="WireMock">
 ```json
@@ -378,7 +390,8 @@ stubFor(get(urlEqualTo("/job/123/status"))
     "jsonBody": { "id": "ch_premium_123" }
   }
 }
-```
+````
+
   </TabItem>
 </Tabs>
 
@@ -418,16 +431,17 @@ const scenarios = {
 
 // Test multi-step flows with stateful behavior
 test('cart accumulates items', async ({ page, switchScenario }) => {
-  await switchScenario(page, 'cart-flow');
+await switchScenario(page, 'cart-flow');
 
-  await page.goto('/products');
-  await page.click('[data-product="widget"]');
-  await page.click('[data-product="gadget"]');
+await page.goto('/products');
+await page.click('[data-product="widget"]');
+await page.click('[data-product="gadget"]');
 
-  await page.goto('/cart');
-  await expect(page.locator('.cart-count')).toContainText('2');
+await page.goto('/cart');
+await expect(page.locator('.cart-count')).toContainText('2');
 });
-```
+
+````
   </TabItem>
   <TabItem label="WireMock">
 ```java
@@ -450,7 +464,8 @@ stubFor(get("/api/cart")
 // For data capture/injection: Custom extension or Handlebars templating
 // Handlebars can access request data:
 // {{request.body}} or {{jsonPath request.body '$.item'}}
-```
+````
+
   </TabItem>
 </Tabs>
 
@@ -460,22 +475,33 @@ stubFor(get("/api/cart")
 
 <CardGrid>
   <Card title="Simple setup" icon="rocket">
-    Just npm install and configure scenarios. No separate server process or network configuration required.
+    Just npm install and configure scenarios. No separate server process or
+    network configuration required.
   </Card>
   <Card title="TypeScript-first development" icon="seti:typescript">
-    Scenarios are TypeScript objects with full type safety. IDE autocomplete, compile-time errors, refactoring support.
+    Scenarios are TypeScript objects with full type safety. IDE autocomplete,
+    compile-time errors, refactoring support.
   </Card>
   <Card title="Parallel test isolation" icon="random">
-    Built-in test ID system lets hundreds of tests run simultaneously with different scenarios—no separate instances needed.
+    Built-in test ID system lets hundreds of tests run simultaneously with
+    different scenarios—no separate instances needed.
   </Card>
   <Card title="First-class Playwright support" icon="seti:playwright">
-    Dedicated fixtures with automatic test ID handling. Each test gets its own scenario state with type-safe switching.
+    Dedicated fixtures with automatic test ID handling. Each test gets its own
+    scenario state with type-safe switching.
   </Card>
   <Card title="Per-test-ID state isolation" icon="list-format">
-    Response sequences and stateful mocks are isolated per test ID—parallel tests never share state.
+    Response sequences and stateful mocks are isolated per test ID—parallel
+    tests never share state.
   </Card>
   <Card title="Next.js multi-process handling" icon="puzzle">
-    Next.js has <a href="https://github.com/vercel/next.js/discussions/68572">documented singleton issues</a> that break MSW. Scenarist's adapter includes built-in <code>globalThis</code> guards—one stable MSW instance regardless of how Next.js loads modules.
+    Next.js has{" "}
+    <a href="https://github.com/vercel/next.js/discussions/68572">
+      documented singleton issues
+    </a>{" "}
+    that break MSW. Scenarist's adapter includes built-in{" "}
+    <code>globalThis</code> guards—one stable MSW instance regardless of how
+    Next.js loads modules.
   </Card>
 </CardGrid>
 
@@ -483,16 +509,20 @@ stubFor(get("/api/cart")
 
 <CardGrid>
   <Card title="Polyglot environment" icon="seti:json">
-    Your team uses multiple languages (Java, Python, .NET). WireMock works with any HTTP client.
+    Your team uses multiple languages (Java, Python, .NET). WireMock works with
+    any HTTP client.
   </Card>
   <Card title="Record and playback" icon="seti:video">
-    Need to capture real API interactions and replay them. WireMock's recording is battle-tested.
+    Need to capture real API interactions and replay them. WireMock's recording
+    is battle-tested.
   </Card>
   <Card title="Existing WireMock investment" icon="approve-check">
-    Team already knows WireMock, has existing stub libraries, or uses WireMock Cloud.
+    Team already knows WireMock, has existing stub libraries, or uses WireMock
+    Cloud.
   </Card>
   <Card title="Contract testing" icon="document">
-    Using WireMock for contract testing with Spring Cloud Contract or similar frameworks.
+    Using WireMock for contract testing with Spring Cloud Contract or similar
+    frameworks.
   </Card>
 </CardGrid>
 
@@ -543,19 +573,19 @@ Point your app at WireMock for internal services while Scenarist mocks external 
 
 ## Summary
 
-| Factor | Scenarist | WireMock |
-|--------|-----------|----------|
-| Setup simplicity | ✓ npm install | JAR/Docker/npm + network config |
-| TypeScript integration | ✓ Native | Via wiremock-captain client |
-| Parallel test isolation | ✓ Header-based | Multiple instances |
-| Runtime switching | ✓ Single API call | Admin API |
-| Playwright integration | ✓ First-class fixtures | Manual HTTP calls |
-| Response sequences | ✓ Built-in | ✓ Built-in (Scenarios) |
-| Stateful mocks | ✓ Per-test-ID isolation | ✓ Global state machine |
-| Next.js multi-process | ✓ [Built-in singleton guards](https://github.com/vercel/next.js/discussions/68572) | Manual workarounds needed |
-| Language support | JavaScript/TypeScript | ✓ Any language |
-| Record/playback | Not supported | ✓ Built-in |
-| Ecosystem maturity | Newer | ✓ Battle-tested |
-| Contract testing | Not supported | ✓ Spring Cloud Contract |
+| Factor                  | Scenarist                                                                          | WireMock                        |
+| ----------------------- | ---------------------------------------------------------------------------------- | ------------------------------- |
+| Setup simplicity        | ✓ npm install                                                                      | JAR/Docker/npm + network config |
+| TypeScript integration  | ✓ Native                                                                           | Via wiremock-captain client     |
+| Parallel test isolation | ✓ Header-based                                                                     | Multiple instances              |
+| Runtime switching       | ✓ Single API call                                                                  | Admin API                       |
+| Playwright integration  | ✓ First-class fixtures                                                             | Manual HTTP calls               |
+| Response sequences      | ✓ Built-in                                                                         | ✓ Built-in (Scenarios)          |
+| Stateful mocks          | ✓ Per-test-ID isolation                                                            | ✓ Global state machine          |
+| Next.js multi-process   | ✓ [Built-in singleton guards](https://github.com/vercel/next.js/discussions/68572) | Manual workarounds needed       |
+| Language support        | JavaScript/TypeScript                                                              | ✓ Any language                  |
+| Record/playback         | Not supported                                                                      | ✓ Built-in                      |
+| Ecosystem maturity      | Newer                                                                              | ✓ Battle-tested                 |
+| Contract testing        | Not supported                                                                      | ✓ Spring Cloud Contract         |
 
 **Bottom line:** For Node.js projects, Scenarist keeps you in a single ecosystem—TypeScript scenarios, npm dependencies, Playwright fixtures, no context-switching to Java or Docker. Choose Scenarist when you value in-process simplicity, header-based parallel test isolation, and first-class Playwright support. Choose WireMock when you're in a polyglot environment, need recording, contract testing, or when your team already has WireMock expertise. Both tools are capable—the choice is primarily about staying in your ecosystem vs. language flexibility.

--- a/apps/docs/src/content/docs/concepts/production-safety.mdx
+++ b/apps/docs/src/content/docs/concepts/production-safety.mdx
@@ -3,7 +3,7 @@ title: Production Safety
 description: How Scenarist ensures zero test code in production bundles
 ---
 
-import { Aside } from '@astrojs/starlight/components';
+import { Aside } from "@astrojs/starlight/components";
 
 Scenarist is **safe to use in production** - your test mocking code will never reach production users.
 
@@ -12,12 +12,13 @@ Scenarist is **safe to use in production** - your test mocking code will never r
 When you deploy to production with `NODE_ENV=production`, Scenarist automatically returns `undefined` without loading any test code. Your bundler (Webpack, Vite, esbuild, etc.) then performs **tree-shaking** to eliminate all Scenarist code from your production bundle.
 
 ```typescript
-import { createScenarist } from '@scenarist/express-adapter';
-import { scenarios } from './scenarios';
+import { createScenarist } from "@scenarist/express-adapter";
+import { scenarios } from "./scenarios";
 
 // In production: returns undefined
 // In development/test: returns working Scenarist instance
-export const scenarist = createScenarist({
+// Note: createScenarist is async - use await
+export const scenarist = await createScenarist({
   enabled: true,
   scenarios,
 });
@@ -30,8 +31,8 @@ All Scenarist adapters use a **production wrapper** that checks `NODE_ENV` befor
 ```typescript
 // Simplified view of what happens inside createScenarist()
 export const createScenarist = (options) => {
-  if (process.env.NODE_ENV === 'production') {
-    return undefined;  // ← Returns immediately, no test code loaded
+  if (process.env.NODE_ENV === "production") {
+    return undefined; // ← Returns immediately, no test code loaded
   }
 
   // Development/test: load implementation
@@ -40,6 +41,7 @@ export const createScenarist = (options) => {
 ```
 
 This pattern ensures:
+
 - ✅ **Zero runtime impact** - Production code paths never execute test logic
 - ✅ **Automatic tree-shaking** - Bundlers eliminate dead code
 - ✅ **No configuration needed** - Works automatically based on NODE_ENV
@@ -196,7 +198,9 @@ du -sh dist/ .next/static/ build/
 **Express (Automatic for Unbundled, Configuration for Bundled):**
 
 <Aside type="tip">
-**Most Express apps deploy unbundled code** and get automatic tree-shaking with zero configuration. Only bundled deployments require additional bundler setup.
+  **Most Express apps deploy unbundled code** and get automatic tree-shaking
+  with zero configuration. Only bundled deployments require additional bundler
+  setup.
 </Aside>
 
 **Unbundled Deployments (Most Common):**
@@ -209,6 +213,7 @@ NODE_ENV=production node src/server.js
 ```
 
 **How it works:**
+
 - `createScenarist()` returns `undefined` at runtime
 - Dynamic imports never execute
 - MSW code **never loads into memory**
@@ -231,7 +236,9 @@ kill $PID
 **Bundled Deployments (esbuild, webpack, Vite, rollup):**
 
 <Aside type="tip">
-Modern bundlers with **code splitting enabled** automatically tree-shake Scenarist with **zero configuration**. The implementation code is split into a separate chunk that is never loaded into memory.
+  Modern bundlers with **code splitting enabled** automatically tree-shake
+  Scenarist with **zero configuration**. The implementation code is split into a
+  separate chunk that is never loaded into memory.
 </Aside>
 
 **Default Approach (Zero Config):**
@@ -253,6 +260,7 @@ rollup -c
 ```
 
 **How it works:**
+
 1. Dynamic import creates code-splitting boundary
 2. Impl code split into separate chunk (e.g., `impl-ABC123.js`)
 3. DefinePlugin makes `if (process.env.NODE_ENV === 'production')` unreachable
@@ -260,6 +268,7 @@ rollup -c
 5. **Chunk file exists on disk but never loads into memory**
 
 **Verification:**
+
 ```bash
 # Build with code splitting
 NODE_ENV=production npm run build
@@ -279,6 +288,7 @@ kill $PID
 ```
 
 **Result:**
+
 - Entry point: ~27kb (94% smaller than single bundle)
 - Impl chunk: ~242kb (exists but never loaded)
 - **Effective delivery: 27kb** (same as conditional exports!)
@@ -289,7 +299,9 @@ kill $PID
 **Optional: Minimal Build Artifacts**
 
 <Aside type="caution">
-For teams needing absolute minimal build artifacts (not delivery size), Scenarist provides **conditional exports**. This requires a GLOBAL bundler flag that affects ALL packages.
+  For teams needing absolute minimal build artifacts (not delivery size),
+  Scenarist provides **conditional exports**. This requires a GLOBAL bundler
+  flag that affects ALL packages.
 </Aside>
 
 Scenarist uses **conditional package.json exports** to provide different entry points:
@@ -298,8 +310,8 @@ Scenarist uses **conditional package.json exports** to provide different entry p
 {
   "exports": {
     ".": {
-      "production": "./dist/setup/production.js",  // Zero dependencies
-      "default": "./dist/index.js"                 // Full implementation
+      "production": "./dist/setup/production.js", // Zero dependencies
+      "default": "./dist/index.js" // Full implementation
     }
   }
 }
@@ -308,55 +320,63 @@ Scenarist uses **conditional package.json exports** to provide different entry p
 The `"production"` condition is **custom** (not a Node.js built-in). Bundlers must be configured to recognize it:
 
 **esbuild:**
+
 ```bash
 esbuild --bundle --splitting --outdir=dist --define:process.env.NODE_ENV='"production"' --conditions=production
 ```
 
 **webpack:**
+
 ```js
 // webpack.config.js
 module.exports = {
-  mode: 'production',
+  mode: "production",
   resolve: {
-    conditionNames: ['production', 'import', 'require']
-  }
+    conditionNames: ["production", "import", "require"],
+  },
 };
 ```
 
 **Vite:**
+
 ```js
 // vite.config.js
 export default {
   resolve: {
-    conditions: ['production']
-  }
+    conditions: ["production"],
+  },
 };
 ```
 
 **rollup:**
+
 ```js
-import resolve from '@rollup/plugin-node-resolve';
+import resolve from "@rollup/plugin-node-resolve";
 
 export default {
   plugins: [
     resolve({
-      exportConditions: ['production']
-    })
-  ]
+      exportConditions: ["production"],
+    }),
+  ],
 };
 ```
 
 <Aside type="caution">
-**WARNING**: The `--conditions` flag is **GLOBAL** and affects ALL packages with conditional exports in your dependency tree, not just Scenarist. This could change behavior of other dependencies unexpectedly.
+  **WARNING**: The `--conditions` flag is **GLOBAL** and affects ALL packages
+  with conditional exports in your dependency tree, not just Scenarist. This
+  could change behavior of other dependencies unexpectedly.
 </Aside>
 
 **Trade-off:**
+
 - ✅ Smallest possible build artifacts (~298kb total vs ~27kb + ~242kb)
 - ⚠️ GLOBAL configuration affects all dependencies
 - ⚠️ May break other packages using conditional exports
 - ⚠️ Requires auditing dependency tree
 
 **When to use conditional exports:**
+
 - Build artifact size is critical (containers, CI/CD storage)
 - Disk space constrained environments
 - You've audited your dependency tree
@@ -453,8 +473,8 @@ name: Verify Production Safety
 on:
   pull_request:
     paths:
-      - 'package.json'
-      - 'src/**'
+      - "package.json"
+      - "src/**"
 
 jobs:
   verify-bundle:
@@ -505,6 +525,7 @@ Run: `npm run verify:production`
 #### What Success Looks Like
 
 **✅ Passing verification:**
+
 - Bundle analyzer shows NO `scenarist` or `msw` packages
 - `grep` search returns no matches (exit code 1)
 - Bundle size same as before adding Scenarist (±1KB)
@@ -512,6 +533,7 @@ Run: `npm run verify:production`
 - Production deployment works normally
 
 **❌ Failed verification (tree-shaking didn't work):**
+
 - Bundle contains `scenarist` or `msw` strings
 - Bundle size significantly larger than expected
 - `createScenarist` function visible in bundle
@@ -536,23 +558,25 @@ NODE_ENV=production npm run build
 Most bundlers enable tree-shaking by default in production mode. Verify config:
 
 **Webpack:**
+
 ```js
 // webpack.config.js
 module.exports = {
-  mode: 'production',  // ← Required
+  mode: "production", // ← Required
   optimization: {
-    usedExports: true,  // ← Should be true (default in production)
-    sideEffects: true,  // ← Should be true (default)
+    usedExports: true, // ← Should be true (default in production)
+    sideEffects: true, // ← Should be true (default)
   },
 };
 ```
 
 **Vite:**
+
 ```js
 // vite.config.js - tree-shaking automatic in production
 export default defineConfig({
   build: {
-    minify: 'terser',  // Or 'esbuild' - both tree-shake
+    minify: "terser", // Or 'esbuild' - both tree-shake
   },
 });
 ```
@@ -561,10 +585,10 @@ export default defineConfig({
 
 ```js
 // ❌ Wrong - prevents tree-shaking
-const scenarist = require('@scenarist/express-adapter');
+const scenarist = require("@scenarist/express-adapter");
 
 // ✅ Correct - enables tree-shaking
-import { createScenarist } from '@scenarist/express-adapter';
+import { createScenarist } from "@scenarist/express-adapter";
 ```
 
 **4. package.json sideEffects field:**
@@ -586,8 +610,8 @@ Ensure TypeScript preserves ES modules:
 // tsconfig.json
 {
   "compilerOptions": {
-    "module": "ES2020",     // ← Or "ESNext", not "CommonJS"
-    "moduleResolution": "bundler",  // ← Or "node16"
+    "module": "ES2020", // ← Or "ESNext", not "CommonJS"
+    "moduleResolution": "bundler" // ← Or "node16"
   }
 }
 ```
@@ -608,6 +632,7 @@ If tree-shaking still fails after checking the above:
    - Output of `npm ls @scenarist/*`
 
 For additional help, see:
+
 - [Production Tree-Shaking Verification](/reference/verification#production-tree-shaking-verification) - Verify code splitting works correctly
 - [Header Propagation in Parallel Tests](/reference/verification#header-propagation-in-parallel-tests) - Troubleshoot test isolation issues
 
@@ -633,7 +658,7 @@ This prevents accidentally calling test methods in production code.
 ### Express
 
 ```typescript
-import { createScenarist } from '@scenarist/express-adapter';
+import { createScenarist } from "@scenarist/express-adapter";
 
 export const scenarist = await createScenarist({
   enabled: true,
@@ -642,7 +667,7 @@ export const scenarist = await createScenarist({
 
 // Type-safe null check required
 if (scenarist) {
-  scenarist.start();  // Only runs in development/test
+  scenarist.start(); // Only runs in development/test
 }
 ```
 
@@ -652,7 +677,7 @@ Both Next.js adapters use the **synchronous pattern** with conditional exports f
 
 ```typescript
 // lib/scenarist.ts
-import { createScenarist } from '@scenarist/nextjs-adapter/app';
+import { createScenarist } from "@scenarist/nextjs-adapter/app";
 // or: import { createScenarist } from '@scenarist/nextjs-adapter/pages';
 
 // Synchronous - no async/await needed
@@ -662,12 +687,13 @@ export const scenarist = createScenarist({
 });
 
 // MSW auto-starts in development/test (when scenarist is defined)
-if (typeof window === 'undefined' && scenarist) {
+if (typeof window === "undefined" && scenarist) {
   scenarist.start();
 }
 ```
 
 **Production behavior:**
+
 - ✅ **Conditional exports** resolve to `production.js` which returns `undefined` immediately
 - ✅ **Zero imports** in production.js guarantees tree-shaking
 - ✅ **Zero configuration:** Works automatically based on `NODE_ENV`
@@ -678,13 +704,13 @@ To avoid `scenarist?.method() ?? fallback` patterns everywhere, both adapters ex
 
 ```typescript
 // App Router API Route
-import { getScenaristHeaders } from '@scenarist/nextjs-adapter/app';
+import { getScenaristHeaders } from "@scenarist/nextjs-adapter/app";
 
 export async function GET(request: Request) {
-  const response = await fetch('http://localhost:3001/products', {
+  const response = await fetch("http://localhost:3001/products", {
     headers: {
-      ...getScenaristHeaders(request),  // Always safe, no guards needed
-      'x-user-tier': 'premium',
+      ...getScenaristHeaders(request), // Always safe, no guards needed
+      "x-user-tier": "premium",
     },
   });
 }
@@ -692,13 +718,13 @@ export async function GET(request: Request) {
 
 ```typescript
 // App Router Server Component
-import { headers } from 'next/headers';
-import { getScenaristHeadersFromReadonlyHeaders } from '@scenarist/nextjs-adapter/app';
+import { headers } from "next/headers";
+import { getScenaristHeadersFromReadonlyHeaders } from "@scenarist/nextjs-adapter/app";
 
 export default async function ProductsPage() {
   const headersList = await headers();
 
-  const response = await fetch('http://localhost:3001/products', {
+  const response = await fetch("http://localhost:3001/products", {
     headers: getScenaristHeadersFromReadonlyHeaders(headersList),
   });
 }
@@ -706,16 +732,17 @@ export default async function ProductsPage() {
 
 ```typescript
 // Pages Router API Route
-import { getScenaristHeaders } from '@scenarist/nextjs-adapter/pages';
+import { getScenaristHeaders } from "@scenarist/nextjs-adapter/pages";
 
 export default async function handler(req, res) {
-  const response = await fetch('http://localhost:3001/products', {
+  const response = await fetch("http://localhost:3001/products", {
     headers: getScenaristHeaders(req),
   });
 }
 ```
 
 **Available helpers:**
+
 - **App Router:**
   - `getScenaristHeaders(request)` - Extract Scenarist headers from Request
   - `getScenaristHeadersFromReadonlyHeaders(headers)` - Extract Scenarist headers from ReadonlyHeaders
@@ -733,6 +760,7 @@ These helpers access global singletons and return safe defaults in production (e
 **No.** Even without `NODE_ENV=production`, Scenarist only activates when explicitly started. The `scenarist?.start()` call is typically in development server setup, not production runtime.
 
 However, **you should always set NODE_ENV=production** for:
+
 - Optimal performance
 - Correct framework behavior
 - Automatic tree-shaking
@@ -740,16 +768,19 @@ However, **you should always set NODE_ENV=production** for:
 ### What about CI/CD environments?
 
 CI/CD environments should use:
+
 - `NODE_ENV=test` for running tests
 - `NODE_ENV=production` for building production bundles
 
 Scenarist works in both modes:
+
 - **Test mode:** Full functionality for scenario-based tests
 - **Production mode:** Returns undefined, enabling tree-shaking
 
 ### Can I verify tree-shaking before deploying?
 
 Yes! See the [Production Tree-Shaking Verification](/reference/verification#production-tree-shaking-verification) section for:
+
 - Step-by-step verification with lsof (proves chunk never loads)
 - Bundle size analysis
 - Build artifact inspection
@@ -768,11 +799,13 @@ If your bundler doesn't tree-shake Scenarist:
 ## Best Practices
 
 1. **Always use `NODE_ENV=production` for production builds**
+
    ```bash
    NODE_ENV=production npm run build
    ```
 
 2. **Add null checks where you use Scenarist**
+
    ```typescript
    if (scenarist) {
      scenarist.start();
@@ -780,6 +813,7 @@ If your bundler doesn't tree-shake Scenarist:
    ```
 
 3. **Verify bundle size in CI/CD**
+
    ```yaml
    - name: Check bundle size
      run: npm run build && npm run analyze
@@ -794,12 +828,12 @@ If your bundler doesn't tree-shake Scenarist:
 
 Scenarist is designed for production safety:
 
-| Aspect | Guarantee |
-|--------|-----------|
-| Production runtime | Zero test code execution |
-| Bundle size | Zero Scenarist code after tree-shaking |
-| Configuration | No environment-specific config needed |
-| Type safety | TypeScript enforces null checks |
-| Performance | No runtime overhead in production |
+| Aspect             | Guarantee                              |
+| ------------------ | -------------------------------------- |
+| Production runtime | Zero test code execution               |
+| Bundle size        | Zero Scenarist code after tree-shaking |
+| Configuration      | No environment-specific config needed  |
+| Type safety        | TypeScript enforces null checks        |
+| Performance        | No runtime overhead in production      |
 
 **The bottom line:** Scenarist's production wrapper + tree-shaking = zero production impact.

--- a/apps/docs/src/content/docs/frameworks/express/example-app.mdx
+++ b/apps/docs/src/content/docs/frameworks/express/example-app.mdx
@@ -14,12 +14,14 @@ The Express example demonstrates HTTP-level integration testing for Express appl
 This example app showcases all major Scenarist features with Express:
 
 ### Core Features
+
 - **Middleware Testing** - Test Express middleware chains with real HTTP requests
 - **Route Handlers** - Test route handlers with different external API responses
 - **Test ID Isolation** - Parallel test execution without interference
 - **Runtime Scenario Switching** - Switch scenarios during test execution
 
 ### Dynamic Response Features
+
 - **Request Matching** - Different responses based on request content
 - **Sequences** - Multi-step processes (polling, async operations)
 - **Stateful Mocks** - State capture and injection across requests
@@ -28,6 +30,7 @@ This example app showcases all major Scenarist features with Express:
 ## Installation
 
 ### Prerequisites
+
 - Node.js 20+
 - pnpm 9+
 
@@ -74,30 +77,48 @@ pnpm test:coverage
 ### Scenarist Setup
 
 **`src/server.ts`** - Express server with Scenarist integration
+
 ```typescript
-import express from 'express';
-import { createScenarist } from '@scenarist/express-adapter';
-import { scenarios } from './scenarios';
+import express from "express";
+import {
+  createScenarist,
+  type ExpressScenarist,
+} from "@scenarist/express-adapter";
+import { scenarios } from "./scenarios";
 
-const app = express();
+// Use async factory pattern for Express apps
+export const createApp = async () => {
+  const app = express();
 
-// Create Scenarist instance
-const scenarist = createScenarist({
-  enabled: process.env.NODE_ENV === 'test',
-  scenarios,
-});
+  // Create Scenarist instance (async - returns Promise)
+  const scenarist = await createScenarist({
+    enabled: process.env.NODE_ENV === "test",
+    scenarios,
+  });
 
-// Register Scenarist middleware
-app.use(scenarist.middleware());
+  // Register Scenarist middleware (only if enabled)
+  if (scenarist) {
+    app.use(scenarist.middleware);
+  }
 
-// Your routes
-app.get('/api/user', async (req, res) => {
-  const response = await fetch('https://api.auth.example.com/user');
-  const user = await response.json();
-  res.json(user);
-});
+  // Your routes
+  app.get("/api/user", async (req, res) => {
+    const response = await fetch("https://api.auth.example.com/user");
+    const user = await response.json();
+    res.json(user);
+  });
 
-export default app;
+  return { app, scenarist };
+};
+
+// Entry point
+const main = async () => {
+  const { app, scenarist } = await createApp();
+  scenarist?.start();
+  app.listen(3000);
+};
+
+main().catch(console.error);
 ```
 
 ### Scenario Definitions
@@ -109,6 +130,7 @@ Key scenarios:
 **`default`** - Standard responses for all tests
 
 **`premiumUser`** - Premium tier user
+
 ```typescript
 premiumUser: {
   id: 'premiumUser',
@@ -125,6 +147,7 @@ premiumUser: {
 ```
 
 **`githubPolling`** - Polling sequence
+
 ```typescript
 githubPolling: {
   id: 'githubPolling',
@@ -144,6 +167,7 @@ githubPolling: {
 ```
 
 **`shoppingCart`** - Stateful shopping cart
+
 ```typescript
 shoppingCart: {
   id: 'shoppingCart',
@@ -171,117 +195,141 @@ shoppingCart: {
 ### Test Examples
 
 **`tests/scenario-switching.test.ts`** - Basic scenario switching
-```typescript
-import request from 'supertest';
-import app from '../src/server';
 
-describe('Scenario Switching', () => {
-  it('should switch to premium user scenario', async () => {
-    const testId = 'test-123';
+```typescript
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import request from "supertest";
+import { createApp } from "../src/server";
+
+// Factory function for test setup - no let variables
+const createTestSetup = async () => {
+  const { app, scenarist } = await createApp();
+  return { app, scenarist };
+};
+
+describe("Scenario Switching", () => {
+  const testContext = createTestSetup();
+
+  beforeAll(async () => {
+    const { scenarist } = await testContext;
+    scenarist?.start();
+  });
+
+  afterAll(async () => {
+    const { scenarist } = await testContext;
+    scenarist?.stop();
+  });
+
+  it("should switch to premium user scenario", async () => {
+    const { app } = await testContext;
+    const testId = "test-123";
 
     // Switch to premiumUser scenario
     await request(app)
-      .post('/__scenario__')
-      .set('x-scenarist-test-id', testId)
-      .send({ scenario: 'premiumUser' });
+      .post("/__scenario__")
+      .set("x-scenarist-test-id", testId)
+      .send({ scenario: "premiumUser" });
 
     // Request uses premium scenario
     const response = await request(app)
-      .get('/api/user')
-      .set('x-scenarist-test-id', testId);
+      .get("/api/user")
+      .set("x-scenarist-test-id", testId);
 
-    expect(response.body.tier).toBe('premium');
+    expect(response.body.tier).toBe("premium");
   });
 });
 ```
 
 **`tests/test-id-isolation.test.ts`** - Parallel test isolation
+
 ```typescript
-describe('Test ID Isolation', () => {
-  it('should isolate scenarios by test ID', async () => {
+describe("Test ID Isolation", () => {
+  it("should isolate scenarios by test ID", async () => {
     // Test 1 uses premiumUser
-    const testId1 = 'test-1';
+    const testId1 = "test-1";
     await request(app)
-      .post('/__scenario__')
-      .set('x-scenarist-test-id', testId1)
-      .send({ scenario: 'premiumUser' });
+      .post("/__scenario__")
+      .set("x-scenarist-test-id", testId1)
+      .send({ scenario: "premiumUser" });
 
     // Test 2 uses standardUser
-    const testId2 = 'test-2';
+    const testId2 = "test-2";
     await request(app)
-      .post('/__scenario__')
-      .set('x-scenarist-test-id', testId2)
-      .send({ scenario: 'standardUser' });
+      .post("/__scenario__")
+      .set("x-scenarist-test-id", testId2)
+      .send({ scenario: "standardUser" });
 
     // Requests are isolated
     const res1 = await request(app)
-      .get('/api/user')
-      .set('x-scenarist-test-id', testId1);
-    expect(res1.body.tier).toBe('premium');
+      .get("/api/user")
+      .set("x-scenarist-test-id", testId1);
+    expect(res1.body.tier).toBe("premium");
 
     const res2 = await request(app)
-      .get('/api/user')
-      .set('x-scenarist-test-id', testId2);
-    expect(res2.body.tier).toBe('standard');
+      .get("/api/user")
+      .set("x-scenarist-test-id", testId2);
+    expect(res2.body.tier).toBe("standard");
   });
 });
 ```
 
 **`tests/dynamic-sequences.test.ts`** - Polling with sequences
+
 ```typescript
-describe('Dynamic Sequences', () => {
-  it('should progress through polling sequence', async () => {
-    const testId = 'test-polling';
+describe("Dynamic Sequences", () => {
+  it("should progress through polling sequence", async () => {
+    const testId = "test-polling";
 
     await request(app)
-      .post('/__scenario__')
-      .set('x-scenarist-test-id', testId)
-      .send({ scenario: 'githubPolling' });
+      .post("/__scenario__")
+      .set("x-scenarist-test-id", testId)
+      .send({ scenario: "githubPolling" });
 
     // First request: pending
     const res1 = await request(app)
-      .get('/api/poll')
-      .set('x-scenarist-test-id', testId);
-    expect(res1.body.status).toBe('pending');
+      .get("/api/poll")
+      .set("x-scenarist-test-id", testId);
+    expect(res1.body.status).toBe("pending");
 
     // Second request: processing
     const res2 = await request(app)
-      .get('/api/poll')
-      .set('x-scenarist-test-id', testId);
-    expect(res2.body.status).toBe('processing');
+      .get("/api/poll")
+      .set("x-scenarist-test-id", testId);
+    expect(res2.body.status).toBe("processing");
 
     // Third request: complete
     const res3 = await request(app)
-      .get('/api/poll')
-      .set('x-scenarist-test-id', testId);
-    expect(res3.body.status).toBe('complete');
+      .get("/api/poll")
+      .set("x-scenarist-test-id", testId);
+    expect(res3.body.status).toBe("complete");
   });
 });
 ```
 
 **`tests/stateful-scenarios.test.ts`** - State capture and injection
+
 ```typescript
-describe('Stateful Scenarios', () => {
-  it('should capture and inject state', async () => {
-    const testId = 'test-cart';
+describe("Stateful Scenarios", () => {
+  it("should capture and inject state", async () => {
+    const testId = "test-cart";
 
     await request(app)
-      .post('/__scenario__')
-      .set('x-scenarist-test-id', testId)
-      .send({ scenario: 'shoppingCart' });
+      .post("/__scenario__")
+      .set("x-scenarist-test-id", testId)
+      .send({ scenario: "shoppingCart" });
 
     // Add item - state captured
     await request(app)
-      .post('/api/cart/add')
-      .set('x-scenarist-test-id', testId)
-      .send({ productId: 'prod-1' });
+      .post("/api/cart/add")
+      .set("x-scenarist-test-id", testId)
+      .send({ productId: "prod-1" });
 
     // Get cart - state injected
     const response = await request(app)
-      .get('/api/cart/items')
-      .set('x-scenarist-test-id', testId);
+      .get("/api/cart/items")
+      .set("x-scenarist-test-id", testId);
 
-    expect(response.body.items).toContain('prod-1');
+    expect(response.body.items).toContain("prod-1");
   });
 });
 ```
@@ -319,7 +367,7 @@ Response to Client
 
 ### File Structure
 
-import { FileTree } from '@astrojs/starlight/components';
+import { FileTree } from "@astrojs/starlight/components";
 
 <FileTree>
 - apps/express-example/
@@ -344,26 +392,26 @@ import { FileTree } from '@astrojs/starlight/components';
 ```typescript
 // Middleware that fetches user from external API
 app.use(async (req, res, next) => {
-  const response = await fetch('https://api.auth.example.com/user');
+  const response = await fetch("https://api.auth.example.com/user");
   req.user = await response.json();
   next();
 });
 
 // Test with different user scenarios
-describe('Auth Middleware', () => {
-  it('should set premium user', async () => {
-    const testId = 'test-premium';
+describe("Auth Middleware", () => {
+  it("should set premium user", async () => {
+    const testId = "test-premium";
 
     await request(app)
-      .post('/__scenario__')
-      .set('x-scenarist-test-id', testId)
-      .send({ scenario: 'premiumUser' });
+      .post("/__scenario__")
+      .set("x-scenarist-test-id", testId)
+      .send({ scenario: "premiumUser" });
 
     const response = await request(app)
-      .get('/api/profile')
-      .set('x-scenarist-test-id', testId);
+      .get("/api/profile")
+      .set("x-scenarist-test-id", testId);
 
-    expect(response.body.user.tier).toBe('premium');
+    expect(response.body.user.tier).toBe("premium");
   });
 });
 ```
@@ -371,40 +419,40 @@ describe('Auth Middleware', () => {
 ### Testing with Request Matching
 
 ```typescript
-import type { ScenaristScenarios } from '@scenarist/express-adapter';
+import type { ScenaristScenarios } from "@scenarist/express-adapter";
 
 // Different responses based on request body
 const scenarios = {
   checkout: {
-    id: 'checkout',
+    id: "checkout",
     mocks: [
       {
-        method: 'POST',
-        url: 'https://api.payment.example.com/charge',
+        method: "POST",
+        url: "https://api.payment.example.com/charge",
         match: { body: { amount: 100 } },
-        response: { status: 200, body: { success: true } }
+        response: { status: 200, body: { success: true } },
       },
       {
-        method: 'POST',
-        url: 'https://api.payment.example.com/charge',
+        method: "POST",
+        url: "https://api.payment.example.com/charge",
         match: { body: { amount: 10000 } },
-        response: { status: 400, body: { error: 'Amount too large' } }
-      }
-    ]
-  }
+        response: { status: 400, body: { error: "Amount too large" } },
+      },
+    ],
+  },
 } as const satisfies ScenaristScenarios;
 ```
 
 ### Testing Default Fallback
 
 ```typescript
-describe('Default Fallback', () => {
-  it('should use default scenario when none specified', async () => {
+describe("Default Fallback", () => {
+  it("should use default scenario when none specified", async () => {
     // No scenario switch - uses default
-    const response = await request(app).get('/api/user');
+    const response = await request(app).get("/api/user");
 
     expect(response.status).toBe(200);
-    expect(response.body.tier).toBe('standard'); // default scenario
+    expect(response.body.tier).toBe("standard"); // default scenario
   });
 });
 ```

--- a/apps/docs/src/content/docs/frameworks/express/getting-started.mdx
+++ b/apps/docs/src/content/docs/frameworks/express/getting-started.mdx
@@ -3,7 +3,7 @@ title: Express - Getting Started
 description: Set up Scenarist with Express in 5 minutes
 ---
 
-import { Aside } from '@astrojs/starlight/components';
+import { Aside } from "@astrojs/starlight/components";
 
 Test your Express APIs with runtime scenario switching. Zero boilerplate setup using AsyncLocalStorage.
 
@@ -11,6 +11,7 @@ Test your Express APIs with runtime scenario switching. Zero boilerplate setup u
 **[View the complete Express example on GitHub →](https://github.com/citypaul/scenarist/tree/main/apps/express-example)**
 
 Clone it, run the tests, and explore working code for scenarios, Supertest patterns, and test isolation.
+
 </Aside>
 
 ## Installation
@@ -26,39 +27,42 @@ npm install -D @playwright/test @scenarist/playwright-helpers
 
 ```typescript
 // src/scenarios.ts
-import type { ScenaristScenario, ScenaristScenarios } from '@scenarist/express-adapter';
+import type {
+  ScenaristScenario,
+  ScenaristScenarios,
+} from "@scenarist/express-adapter";
 
 // ✅ RECOMMENDED - Default scenario with complete happy path
 const defaultScenario: ScenaristScenario = {
-  id: 'default',
-  name: 'Happy Path',
-  description: 'All external APIs succeed with valid responses',
+  id: "default",
+  name: "Happy Path",
+  description: "All external APIs succeed with valid responses",
   mocks: [
     // Stripe: Successful payment
     {
-      method: 'POST',
-      url: 'https://api.stripe.com/v1/charges',
+      method: "POST",
+      url: "https://api.stripe.com/v1/charges",
       response: {
         status: 200,
-        body: { id: 'ch_123', status: 'succeeded', amount: 5000 },
+        body: { id: "ch_123", status: "succeeded", amount: 5000 },
       },
     },
     // Auth0: Authenticated user
     {
-      method: 'GET',
-      url: 'https://api.auth0.com/userinfo',
+      method: "GET",
+      url: "https://api.auth0.com/userinfo",
       response: {
         status: 200,
-        body: { sub: 'user_123', email: 'john@example.com', tier: 'standard' },
+        body: { sub: "user_123", email: "john@example.com", tier: "standard" },
       },
     },
     // SendGrid: Email sent successfully
     {
-      method: 'POST',
-      url: 'https://api.sendgrid.com/v3/mail/send',
+      method: "POST",
+      url: "https://api.sendgrid.com/v3/mail/send",
       response: {
         status: 202,
-        body: { message_id: 'msg_123' },
+        body: { message_id: "msg_123" },
       },
     },
   ],
@@ -66,17 +70,19 @@ const defaultScenario: ScenaristScenario = {
 
 // Specialized scenario: Override ONLY Stripe for payment failure
 const cardDeclinedScenario: ScenaristScenario = {
-  id: 'cardDeclined',
-  name: 'Card Declined',
-  description: 'Stripe declines payment, everything else succeeds',
+  id: "cardDeclined",
+  name: "Card Declined",
+  description: "Stripe declines payment, everything else succeeds",
   mocks: [
     // Override: Stripe declines payment
     {
-      method: 'POST',
-      url: 'https://api.stripe.com/v1/charges',
+      method: "POST",
+      url: "https://api.stripe.com/v1/charges",
       response: {
         status: 402,
-        body: { error: { code: 'card_declined', message: 'Your card was declined' } },
+        body: {
+          error: { code: "card_declined", message: "Your card was declined" },
+        },
       },
     },
     // Auth0 and SendGrid automatically fall back to default (happy path)
@@ -92,111 +98,145 @@ export const scenarios = {
 **2. Set up Scenarist in your Express app:**
 
 ```typescript
-// src/server.ts
-import express from 'express';
-import { createScenarist } from '@scenarist/express-adapter';
-import { scenarios } from './scenarios';
+// src/app.ts
+import express from "express";
+import {
+  createScenarist,
+  type ExpressScenarist,
+} from "@scenarist/express-adapter";
+import { scenarios } from "./scenarios";
 
-const app = express();
-app.use(express.json());
+// Use async factory pattern for Express apps
+export const createApp = async () => {
+  const app = express();
+  app.use(express.json());
 
-// Create Scenarist instance with scenarios
-const scenarist = createScenarist({
-  enabled: process.env.NODE_ENV === 'test',
-  scenarios,
-});
-
-// Add Scenarist middleware BEFORE your routes
-app.use(scenarist.middleware);
-
-// Your routes run normally - Scenarist just mocks external APIs
-app.post('/api/checkout', async (req, res) => {
-  const { amount, token } = req.body;
-
-  // Your validation runs
-  if (amount < 1) {
-    return res.status(400).json({ error: 'Invalid amount' });
-  }
-
-  // External Stripe call is mocked by Scenarist
-  const charge = await fetch('https://api.stripe.com/v1/charges', {
-    method: 'POST',
-    headers: { 'Authorization': `Bearer ${process.env.STRIPE_KEY}` },
-    body: JSON.stringify({ amount, source: token }),
+  // Create Scenarist instance (async - returns Promise)
+  const scenarist = await createScenarist({
+    enabled: process.env.NODE_ENV === "test",
+    scenarios,
   });
 
-  const result = await charge.json();
-
-  // Your business logic runs
-  if (charge.status === 200) {
-    return res.json({ success: true, chargeId: result.id });
-  } else {
-    return res.status(402).json({ error: result.error.message });
+  // Add Scenarist middleware BEFORE your routes (only if enabled)
+  if (scenarist) {
+    app.use(scenarist.middleware);
   }
-});
 
-app.listen(3000, () => console.log('Server running on :3000'));
+  // Your routes run normally - Scenarist just mocks external APIs
+  app.post("/api/checkout", async (req, res) => {
+    const { amount, token } = req.body;
+
+    // Your validation runs
+    if (amount < 1) {
+      return res.status(400).json({ error: "Invalid amount" });
+    }
+
+    // External Stripe call is mocked by Scenarist
+    const charge = await fetch("https://api.stripe.com/v1/charges", {
+      method: "POST",
+      headers: { Authorization: `Bearer ${process.env.STRIPE_KEY}` },
+      body: JSON.stringify({ amount, source: token }),
+    });
+
+    const result = await charge.json();
+
+    // Your business logic runs
+    if (charge.status === 200) {
+      return res.json({ success: true, chargeId: result.id });
+    } else {
+      return res.status(402).json({ error: result.error.message });
+    }
+  });
+
+  return { app, scenarist };
+};
+
+// src/server.ts - Entry point
+const main = async () => {
+  const { app, scenarist } = await createApp();
+
+  if (scenarist) {
+    scenarist.start();
+  }
+
+  app.listen(3000, () => console.log("Server running on :3000"));
+};
+
+main().catch(console.error);
 ```
+
+````
 
 **3. Install testing dependencies:**
 
 ```bash
 npm install -D vitest supertest @types/supertest
-```
+````
 
 **4. Write your tests:**
 
 ```typescript
 // tests/checkout.test.ts
-import { describe, it, expect, beforeAll, afterAll } from 'vitest';
-import request from 'supertest';
-import { SCENARIST_TEST_ID_HEADER } from '@scenarist/express-adapter';
-import { createApp } from '../src/server'; // Your Express app factory
-import { scenarios } from '../src/scenarios';
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import request from "supertest";
+import { SCENARIST_TEST_ID_HEADER } from "@scenarist/express-adapter";
+import { createApp } from "../src/app";
 
-describe('Checkout API', () => {
-  const { app, scenarist } = createApp();
+// Factory function for test setup - no let variables
+const createTestSetup = async () => {
+  const { app, scenarist } = await createApp();
+  return { app, scenarist };
+};
 
-  beforeAll(() => {
-    scenarist.start(); // Start MSW
+describe("Checkout API", () => {
+  const testContext = createTestSetup();
+
+  beforeAll(async () => {
+    const { scenarist } = await testContext;
+    scenarist?.start(); // Start MSW
   });
 
-  afterAll(() => {
-    scenarist.stop(); // Stop MSW
+  afterAll(async () => {
+    const { scenarist } = await testContext;
+    scenarist?.stop(); // Stop MSW
   });
 
-  it('processes payment successfully', async () => {
+  it("processes payment successfully", async () => {
+    const { app, scenarist } = await testContext;
+
     // Switch to default scenario
     await request(app)
-      .post(scenarist.config.endpoints.setScenario)
-      .set(SCENARIST_TEST_ID_HEADER, 'test-1')
-      .send({ scenario: 'default' });
+      .post(scenarist!.config.endpoints.setScenario)
+      .set(SCENARIST_TEST_ID_HEADER, "test-1")
+      .send({ scenario: "default" });
 
     // Make API request - your Express route runs normally
     const response = await request(app)
-      .post('/api/checkout')
-      .set(SCENARIST_TEST_ID_HEADER, 'test-1')
-      .send({ amount: 5000, token: 'tok_test' });
+      .post("/api/checkout")
+      .set(SCENARIST_TEST_ID_HEADER, "test-1")
+      .send({ amount: 5000, token: "tok_test" });
 
     expect(response.status).toBe(200);
     expect(response.body.success).toBe(true);
-    expect(response.body.chargeId).toBe('ch_123');
+    expect(response.body.chargeId).toBe("ch_123");
   });
 
-  it('handles card declined error', async () => {
+  it("handles card declined error", async () => {
+    const { app, scenarist } = await testContext;
+
     // Switch to cardDeclined scenario
     await request(app)
-      .post(scenarist.config.endpoints.setScenario)
-      .set(SCENARIST_TEST_ID_HEADER, 'test-2')
-      .send({ scenario: 'cardDeclined' });
+      .post(scenarist!.config.endpoints.setScenario)
+      .set(SCENARIST_TEST_ID_HEADER, "test-2")
+      .send({ scenario: "cardDeclined" });
 
     const response = await request(app)
-      .post('/api/checkout')
-      .set(SCENARIST_TEST_ID_HEADER, 'test-2')
-      .send({ amount: 5000, token: 'tok_test' });
+      .post("/api/checkout")
+      .set(SCENARIST_TEST_ID_HEADER, "test-2")
+      .send({ amount: 5000, token: "tok_test" });
 
     expect(response.status).toBe(402);
-    expect(response.body.error).toContain('declined');
+    expect(response.body.error).toContain("declined");
   });
 });
 ```
@@ -220,17 +260,18 @@ Include the test ID header on **both** scenario switch requests AND actual API r
 // Step 1: Switch scenario (with test ID header)
 await request(app)
   .post(scenarist.config.endpoints.setScenario)
-  .set(SCENARIST_TEST_ID_HEADER, 'test-1')  // ← Test ID header
-  .send({ scenario: 'cardDeclined' });
+  .set(SCENARIST_TEST_ID_HEADER, "test-1") // ← Test ID header
+  .send({ scenario: "cardDeclined" });
 
 // Step 2: Make API request (with SAME test ID header)
 const response = await request(app)
-  .post('/api/checkout')
-  .set(SCENARIST_TEST_ID_HEADER, 'test-1')  // ← Same test ID
-  .send({ amount: 5000, token: 'tok_test' });
+  .post("/api/checkout")
+  .set(SCENARIST_TEST_ID_HEADER, "test-1") // ← Same test ID
+  .send({ amount: 5000, token: "tok_test" });
 ```
 
 **What happens:**
+
 1. First request switches to `'cardDeclined'` scenario for test ID `'test-1'`
 2. Second request includes same test ID header
 3. AsyncLocalStorage associates the request with `'test-1'`
@@ -248,6 +289,7 @@ The header name is standardized to `'x-scenarist-test-id'`:
 ```
 
 **Why use `SCENARIST_TEST_ID_HEADER`?**
+
 - Avoids magic strings (clear intent)
 - Type-safe (TypeScript will catch typos)
 - Consistent across all Scenarist packages
@@ -257,33 +299,33 @@ The header name is standardized to `'x-scenarist-test-id'`:
 Test IDs enable **parallel test execution** without interference:
 
 ```typescript
-describe('Parallel checkout tests', () => {
-  it('test 1: successful payment', async () => {
+describe("Parallel checkout tests", () => {
+  it("test 1: successful payment", async () => {
     // Uses test ID 'test-1'
     await request(app)
       .post(scenarist.config.endpoints.setScenario)
-      .set(SCENARIST_TEST_ID_HEADER, 'test-1')
-      .send({ scenario: 'default' });
+      .set(SCENARIST_TEST_ID_HEADER, "test-1")
+      .send({ scenario: "default" });
 
     const response = await request(app)
-      .post('/api/checkout')
-      .set(SCENARIST_TEST_ID_HEADER, 'test-1')
-      .send({ amount: 5000, token: 'tok_test' });
+      .post("/api/checkout")
+      .set(SCENARIST_TEST_ID_HEADER, "test-1")
+      .send({ amount: 5000, token: "tok_test" });
 
     expect(response.status).toBe(200);
   });
 
-  it('test 2: card declined', async () => {
+  it("test 2: card declined", async () => {
     // Uses test ID 'test-2' - runs simultaneously with test 1
     await request(app)
       .post(scenarist.config.endpoints.setScenario)
-      .set(SCENARIST_TEST_ID_HEADER, 'test-2')
-      .send({ scenario: 'cardDeclined' });
+      .set(SCENARIST_TEST_ID_HEADER, "test-2")
+      .send({ scenario: "cardDeclined" });
 
     const response = await request(app)
-      .post('/api/checkout')
-      .set(SCENARIST_TEST_ID_HEADER, 'test-2')
-      .send({ amount: 5000, token: 'tok_test' });
+      .post("/api/checkout")
+      .set(SCENARIST_TEST_ID_HEADER, "test-2")
+      .send({ amount: 5000, token: "tok_test" });
 
     expect(response.status).toBe(402);
   });
@@ -291,6 +333,7 @@ describe('Parallel checkout tests', () => {
 ```
 
 **Both tests run in parallel:**
+
 - Test 1 uses scenario `'default'` via test ID `'test-1'`
 - Test 2 uses scenario `'cardDeclined'` via test ID `'test-2'`
 - No interference because test IDs isolate scenarios and state
@@ -302,12 +345,13 @@ If you forget to include the test ID header:
 ```typescript
 // ❌ Missing test ID header
 const response = await request(app)
-  .post('/api/checkout')
+  .post("/api/checkout")
   // .set(SCENARIST_TEST_ID_HEADER, 'test-1')  ← MISSING!
-  .send({ amount: 5000, token: 'tok_test' });
+  .send({ amount: 5000, token: "tok_test" });
 ```
 
 **What happens:**
+
 - Request uses the `'default'` scenario (fallback behavior)
 - If you switched to a different scenario, it won't be used
 - May cause confusing test failures (wrong scenario active)
@@ -319,12 +363,12 @@ const response = await request(app)
 If your Express routes make internal fetch calls to other services, you must manually propagate the test ID header:
 
 ```typescript
-app.get('/api/dashboard', async (req, res) => {
+app.get("/api/dashboard", async (req, res) => {
   // Extract test ID from incoming request
-  const testId = req.get(SCENARIST_TEST_ID_HEADER) || 'default-test';
+  const testId = req.get(SCENARIST_TEST_ID_HEADER) || "default-test";
 
   // Include test ID in internal fetch
-  const response = await fetch('http://localhost:3001/api/user', {
+  const response = await fetch("http://localhost:3001/api/user", {
     headers: {
       [SCENARIST_TEST_ID_HEADER]: testId,
     },
@@ -336,6 +380,7 @@ app.get('/api/dashboard', async (req, res) => {
 ```
 
 **Why this is needed:**
+
 - AsyncLocalStorage only tracks the current request
 - Internal fetch calls are new requests (separate context)
 - Must explicitly pass test ID header to maintain isolation
@@ -344,6 +389,7 @@ app.get('/api/dashboard', async (req, res) => {
 We recommend using **Supertest** with **Vitest** for testing Express applications. Supertest is designed specifically for HTTP API testing and provides a clean, fluent interface for making requests and assertions.
 
 **Why Supertest?**
+
 - Direct HTTP requests to your Express app (no browser needed)
 - Fluent API for building requests and setting headers
 - Works perfectly with Express middleware and route handlers
@@ -373,6 +419,7 @@ NODE_ENV=production node src/server.js
 ```
 
 **Tree-shaking is automatic** with zero configuration:
+
 - `createScenarist()` returns `undefined` at runtime
 - Dynamic imports never execute
 - MSW code **never loads into memory**
@@ -388,8 +435,8 @@ Scenarist uses **conditional package.json exports** to provide different entry p
 {
   "exports": {
     ".": {
-      "production": "./dist/setup/production.js",  // Zero dependencies
-      "default": "./dist/index.js"                 // Full implementation
+      "production": "./dist/setup/production.js", // Zero dependencies
+      "default": "./dist/index.js" // Full implementation
     }
   }
 }
@@ -398,6 +445,7 @@ Scenarist uses **conditional package.json exports** to provide different entry p
 The `"production"` condition is **custom** (not a Node.js built-in). Bundlers must be configured to recognize it:
 
 **esbuild:**
+
 ```json
 {
   "scripts": {
@@ -407,44 +455,49 @@ The `"production"` condition is **custom** (not a Node.js built-in). Bundlers mu
 ```
 
 **webpack:**
+
 ```js
 // webpack.config.js
 module.exports = {
-  mode: 'production',
+  mode: "production",
   resolve: {
-    conditionNames: ['production', 'import', 'require']
-  }
+    conditionNames: ["production", "import", "require"],
+  },
 };
 ```
 
 **Vite:**
+
 ```js
 // vite.config.js
 export default {
   resolve: {
-    conditions: ['production']
-  }
+    conditions: ["production"],
+  },
 };
 ```
 
 **rollup:**
+
 ```js
-import resolve from '@rollup/plugin-node-resolve';
+import resolve from "@rollup/plugin-node-resolve";
 
 export default {
   plugins: [
     resolve({
-      exportConditions: ['production']
-    })
-  ]
+      exportConditions: ["production"],
+    }),
+  ],
 };
 ```
 
 **Results:**
+
 - ✅ Bundle size: 618kb → 298kb (52% reduction)
 - ✅ Zero MSW code in production bundle
 
 **Verification:**
+
 ```bash
 # Build with bundler configuration
 npm run build:production

--- a/apps/docs/src/content/docs/reference/ephemeral-endpoints.mdx
+++ b/apps/docs/src/content/docs/reference/ephemeral-endpoints.mdx
@@ -10,10 +10,11 @@ Scenarist creates **ephemeral endpoints** that only exist when testing is enable
 The `enabled` flag controls whether Scenarist's testing infrastructure is active:
 
 ```typescript
-import { createScenarist } from '@scenarist/express-adapter';
+import { createScenarist } from "@scenarist/express-adapter";
 
-const scenarist = createScenarist({
-  enabled: process.env.NODE_ENV === 'test',  // Only in test environment
+// Note: createScenarist is async - use await
+const scenarist = await createScenarist({
+  enabled: process.env.NODE_ENV === "test", // Only in test environment
   scenarios,
 });
 ```
@@ -21,16 +22,19 @@ const scenarist = createScenarist({
 ### When `enabled: true` (Test Mode)
 
 **Endpoints are active:**
+
 - `POST /__scenario__` accepts scenario switch requests
 - `GET /__scenario__` returns active scenario
 - Both endpoints process requests normally
 
 **Middleware extracts test IDs:**
+
 - Reads `x-scenarist-test-id` header from requests
 - Routes requests to correct scenario
 - Maintains test isolation
 
 **MSW is registered:**
+
 - Handlers created from scenario definitions
 - External API calls intercepted
 - Responses returned based on active scenario
@@ -38,17 +42,20 @@ const scenarist = createScenarist({
 ### When `enabled: false` (Production Mode)
 
 **Endpoints return 404:**
+
 ```typescript
 // Request: POST /__scenario__
 // Response: 404 Not Found
 ```
 
 **Middleware no-ops:**
+
 - Extracts no headers
 - Adds no overhead
 - Passes requests through unchanged
 
 **MSW is not registered:**
+
 - No handlers created
 - No interception occurs
 - External APIs called normally
@@ -62,8 +69,8 @@ Scenarist provides multiple layers of production safety:
 ### 1. Configuration Check
 
 ```typescript
-const scenarist = createScenarist({
-  enabled: process.env.NODE_ENV !== 'production',  // Explicit check
+const scenarist = await createScenarist({
+  enabled: process.env.NODE_ENV !== "production", // Explicit check
   scenarios,
 });
 ```
@@ -75,12 +82,12 @@ const scenarist = createScenarist({
 Even if `enabled` accidentally left as `true`, endpoints can be configured to non-standard paths:
 
 ```typescript
-const scenarist = createScenarist({
+const scenarist = await createScenarist({
   enabled: true,
   scenarios,
   endpoints: {
-    setScenario: '/__internal_test_scenario_switch__',  // Obscure path
-    getScenario: '/__internal_test_scenario_status__',
+    setScenario: "/__internal_test_scenario_switch__", // Obscure path
+    getScenario: "/__internal_test_scenario_status__",
   },
 });
 ```
@@ -106,7 +113,7 @@ MSW handlers only registered when `enabled: true`:
 ```typescript
 // Next.js example
 if (scenarist.config.enabled) {
-  scenarist.start();  // Registers MSW handlers
+  scenarist.start(); // Registers MSW handlers
 }
 // In production: handlers never registered
 ```
@@ -119,21 +126,21 @@ Each test gets a unique test ID that routes requests to the correct scenario:
 
 ```typescript
 // Test 1
-test('handles success', async ({ page, switchScenario }) => {
-  const testId = await switchScenario(page, 'success');
+test("handles success", async ({ page, switchScenario }) => {
+  const testId = await switchScenario(page, "success");
   // testId = 'test-abc123' (auto-generated UUID)
 
-  await page.goto('/api/payment');
+  await page.goto("/api/payment");
   // Request includes header: x-scenarist-test-id: test-abc123
   // Scenarist routes to 'success' scenario for this test ID
 });
 
 // Test 2 (runs in parallel)
-test('handles error', async ({ page, switchScenario }) => {
-  const testId = await switchScenario(page, 'error');
+test("handles error", async ({ page, switchScenario }) => {
+  const testId = await switchScenario(page, "error");
   // testId = 'test-def456' (different UUID)
 
-  await page.goto('/api/payment');
+  await page.goto("/api/payment");
   // Request includes header: x-scenarist-test-id: test-def456
   // Scenarist routes to 'error' scenario for this test ID
 });
@@ -156,7 +163,7 @@ test('handles error', async ({ page, switchScenario }) => {
 The test ID header is standardized to `'x-scenarist-test-id'`. Use the `SCENARIST_TEST_ID_HEADER` constant from your adapter package:
 
 ```typescript
-import { SCENARIST_TEST_ID_HEADER } from '@scenarist/express-adapter';
+import { SCENARIST_TEST_ID_HEADER } from "@scenarist/express-adapter";
 // SCENARIST_TEST_ID_HEADER === 'x-scenarist-test-id'
 ```
 
@@ -168,31 +175,31 @@ import { SCENARIST_TEST_ID_HEADER } from '@scenarist/express-adapter';
 
 ```typescript
 // tests/fixtures.ts - Set up once
-import { withScenarios, expect } from '@scenarist/playwright-helpers';
-import { scenarios } from './scenarios';
+import { withScenarios, expect } from "@scenarist/playwright-helpers";
+import { scenarios } from "./scenarios";
 
 export const test = withScenarios(scenarios);
 export { expect };
 
 // tests/my-test.spec.ts - Use in tests
-import { test, expect } from './fixtures'; // ✅ Import from fixtures
+import { test, expect } from "./fixtures"; // ✅ Import from fixtures
 
-test('my test', async ({ page, switchScenario }) => {
-  await switchScenario(page, 'success'); // ✅ Type-safe scenario IDs
+test("my test", async ({ page, switchScenario }) => {
+  await switchScenario(page, "success"); // ✅ Type-safe scenario IDs
   // Helper automatically:
   // 1. Generates unique test ID
   // 2. Calls POST /__scenario__ with test ID header
   // 3. Sets page.setExtraHTTPHeaders({ 'x-scenarist-test-id': testId })
 
-  await page.goto('/profile');
+  await page.goto("/profile");
   // All navigation requests include x-scenarist-test-id header
 
-  await page.request.post('/api/data', { data: { foo: 'bar' } });
+  await page.request.post("/api/data", { data: { foo: "bar" } });
   // API requests need explicit test ID (Playwright limitation):
-  const testId = await switchScenario(page, 'success');
-  await page.request.post('/api/data', {
-    headers: { 'x-scenarist-test-id': testId },  // Manual header for page.request
-    data: { foo: 'bar' },
+  const testId = await switchScenario(page, "success");
+  await page.request.post("/api/data", {
+    headers: { "x-scenarist-test-id": testId }, // Manual header for page.request
+    data: { foo: "bar" },
   });
 });
 ```
@@ -203,7 +210,7 @@ When no test ID header is present, Scenarist uses a default test ID:
 
 ```typescript
 // Request without x-scenarist-test-id header
-GET /api/user
+GET / api / user;
 // No x-scenarist-test-id header
 
 // Scenarist uses default test ID: 'default-test'
@@ -219,16 +226,14 @@ Traditional E2E testing forces **sequential execution** because of shared global
 ```typescript
 // ❌ Traditional approach - shared MSW handlers
 beforeAll(() => {
-  server.use(
-    http.get('/api/user', () => HttpResponse.json({ role: 'admin' }))
-  );
+  server.use(http.get("/api/user", () => HttpResponse.json({ role: "admin" })));
 });
 
-test('test 1: admin view', () => {
+test("test 1: admin view", () => {
   // Uses global handler: admin
 });
 
-test('test 2: guest view', () => {
+test("test 2: guest view", () => {
   // PROBLEM: Still sees admin handler!
   // Must run sequentially or reset handlers between tests
 });
@@ -238,13 +243,13 @@ Scenarist enables **parallel execution** via test ID isolation:
 
 ```typescript
 // ✅ Scenarist approach - isolated scenarios
-test('test 1: admin view', async ({ switchScenario }) => {
-  await switchScenario(page, 'admin-user');
+test("test 1: admin view", async ({ switchScenario }) => {
+  await switchScenario(page, "admin-user");
   // Test ID: test-1 → Scenario: admin-user
 });
 
-test('test 2: guest view', async ({ switchScenario }) => {
-  await switchScenario(page, 'guest-user');
+test("test 2: guest view", async ({ switchScenario }) => {
+  await switchScenario(page, "guest-user");
   // Test ID: test-2 → Scenario: guest-user
   // Runs in parallel with test 1, no interference
 });
@@ -284,18 +289,18 @@ NODE_ENV=test SCENARIO=edge npm start
 // NODE_ENV=test npm start
 
 // Switch scenarios at runtime
-test('success case', async ({ switchScenario }) => {
-  await switchScenario(page, 'success');
+test("success case", async ({ switchScenario }) => {
+  await switchScenario(page, "success");
   // Instant scenario switch, no restart
 });
 
-test('error case', async ({ switchScenario }) => {
-  await switchScenario(page, 'error');
+test("error case", async ({ switchScenario }) => {
+  await switchScenario(page, "error");
   // Instant scenario switch, no restart
 });
 
-test('edge case', async ({ switchScenario }) => {
-  await switchScenario(page, 'edge');
+test("edge case", async ({ switchScenario }) => {
+  await switchScenario(page, "edge");
   // Instant scenario switch, no restart
 });
 ```
@@ -329,6 +334,7 @@ curl -X POST http://localhost:3000/__scenario__ \
 ```
 
 **Use cases:**
+
 - Demo different scenarios to stakeholders
 - Debug edge cases locally
 - Validate UI behavior across scenarios
@@ -369,12 +375,12 @@ Scenarios are stored in-memory (current implementation):
 const scenarioStore = new Map<string, ActiveScenario>();
 
 // After switchScenario('test-abc123', 'payment-error')
-scenarioStore.set('test-abc123', {
-  scenarioId: 'payment-error',
+scenarioStore.set("test-abc123", {
+  scenarioId: "payment-error",
 });
 
 // On request with x-scenarist-test-id: test-abc123
-const activeScenario = scenarioStore.get('test-abc123');
+const activeScenario = scenarioStore.get("test-abc123");
 // { scenarioId: 'payment-error' }
 ```
 
@@ -390,12 +396,12 @@ const stateStore = new Map<string, Record<string, unknown>>();
 const sequenceStore = new Map<string, SequencePosition>();
 
 // Test ID: test-abc123
-stateStore.set('test-abc123', { cartItems: ['item-1', 'item-2'] });
-sequenceStore.set('test-abc123:scenario:mockIndex', { position: 2 });
+stateStore.set("test-abc123", { cartItems: ["item-1", "item-2"] });
+sequenceStore.set("test-abc123:scenario:mockIndex", { position: 2 });
 
 // Test ID: test-def456
-stateStore.set('test-def456', { cartItems: ['item-3'] });
-sequenceStore.set('test-def456:scenario:mockIndex', { position: 0 });
+stateStore.set("test-def456", { cartItems: ["item-3"] });
+sequenceStore.set("test-def456:scenario:mockIndex", { position: 0 });
 
 // Tests have independent state and sequence positions
 ```
@@ -405,9 +411,9 @@ sequenceStore.set('test-def456:scenario:mockIndex', { position: 0 });
 Complete configuration options related to ephemeral endpoints:
 
 ```typescript
-const scenarist = createScenarist({
+const scenarist = await createScenarist({
   // Enable/disable testing infrastructure
-  enabled: process.env.NODE_ENV === 'test',
+  enabled: process.env.NODE_ENV === "test",
 
   // Scenario definitions
   scenarios: {
@@ -417,8 +423,8 @@ const scenarist = createScenarist({
 
   // Endpoint paths (configurable)
   endpoints: {
-    setScenario: '/__scenario__',     // POST: switch scenario
-    getScenario: '/__scenario__',     // GET: get active scenario
+    setScenario: "/__scenario__", // POST: switch scenario
+    getScenario: "/__scenario__", // GET: get active scenario
   },
   // Note: Test ID header is standardized to 'x-scenarist-test-id'
   // Use SCENARIST_TEST_ID_HEADER constant from your adapter package
@@ -429,4 +435,4 @@ const scenarist = createScenarist({
 
 - [Scenario Format →](/concepts/scenario-format) - Learn the complete scenario structure
 - [Default Mocks →](/concepts/default-mocks) - Understand override behavior
-- [Endpoint APIs →](/reference/api-endpoints) - Reference for GET/POST /__scenario__
+- [Endpoint APIs →](/reference/api-endpoints) - Reference for GET/POST /**scenario**

--- a/docs/templates/ADAPTER_README_TEMPLATE.md
+++ b/docs/templates/ADAPTER_README_TEMPLATE.md
@@ -119,7 +119,9 @@ export const successScenario: ScenaristScenario = {
 import { createScenarist } from "@scenarist/[framework]-adapter";
 import { successScenario } from "./scenarios";
 
-export const scenarist = createScenarist({
+// Note: For Express adapter, createScenarist is async - use await
+// Check your specific adapter documentation for sync/async behavior
+export const scenarist = await createScenarist({
   enabled: process.env.NODE_ENV === "test",
   defaultScenario: successScenario,
 });


### PR DESCRIPTION
## Summary

- Fix all Express documentation examples to correctly show `await createScenarist(...)` instead of synchronous usage
- The `createScenarist()` function returns `Promise<ExpressScenarist<T> | undefined>`, but docs showed synchronous patterns causing TypeScript errors for users

## Problem

Documentation at `/frameworks/express/getting-started` showed:

```typescript
const scenarist = createScenarist({ enabled: true, scenarios });
app.use(scenarist.middleware);
```

But the actual type signature is:

```typescript
export declare const createScenarist: <T extends ScenaristScenarios>(
  options: ExpressAdapterOptions<T>
) => Promise<ExpressScenarist<T> | undefined>;
```

This caused TypeScript error: `Property 'middleware' does not exist on type 'Promise<ExpressScenarist<...>>'`

## Solution

Updated all Express documentation to use the correct async pattern with factory functions:

```typescript
export const createApp = async () => {
  const app = express();
  const scenarist = await createScenarist({ enabled: true, scenarios });
  if (scenarist) {
    app.use(scenarist.middleware);
  }
  return { app, scenarist };
};
```

## Files Changed

- `packages/express-adapter/README.md`
- `apps/express-example/README.md`
- `apps/docs/src/content/docs/frameworks/express/getting-started.mdx`
- `apps/docs/src/content/docs/frameworks/express/example-app.mdx`
- `apps/docs/src/content/docs/reference/ephemeral-endpoints.mdx`
- `apps/docs/src/content/docs/concepts/production-safety.mdx`
- `apps/docs/src/content/docs/comparison/vs-wiremock.mdx`
- `apps/docs/src/content/docs/comparison/vs-testcontainers.mdx`
- `docs/templates/ADAPTER_README_TEMPLATE.md`

## Changeset

Included patch changeset for `@scenarist/express-adapter` (documentation only).