### PR TITLE
fix: sync all package versions and add internal packages to fixed group

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -7,6 +7,8 @@
   "commit": false,
   "fixed": [
     [
+      "@scenarist/core",
+      "@scenarist/msw-adapter",
       "@scenarist/express-adapter",
       "@scenarist/nextjs-adapter",
       "@scenarist/playwright-helpers"

--- a/.changeset/sync-all-package-versions.md
+++ b/.changeset/sync-all-package-versions.md
@@ -1,0 +1,15 @@
+---
+"@scenarist/core": patch
+"@scenarist/msw-adapter": patch
+"@scenarist/express-adapter": patch
+"@scenarist/nextjs-adapter": patch
+"@scenarist/playwright-helpers": patch
+---
+
+Sync all package versions and add internal packages to fixed version group
+
+This release ensures all Scenarist packages are versioned together:
+
+- Added `@scenarist/core` and `@scenarist/msw-adapter` to the fixed version group
+- All packages now release with synchronized version numbers
+- Prevents version drift between internal and published packages

--- a/internal/core/package.json
+++ b/internal/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@scenarist/core",
-  "version": "0.1.3",
+  "version": "0.1.15",
   "description": "Internal: Hexagonal architecture core for scenario-based testing with MSW",
   "author": "Paul Hammond (citypaul) <paul@packsoftware.co.uk>",
   "license": "MIT",

--- a/internal/msw-adapter/package.json
+++ b/internal/msw-adapter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@scenarist/msw-adapter",
-  "version": "0.1.3",
+  "version": "0.1.15",
   "description": "Internal: MSW integration layer for Scenarist framework adapters",
   "author": "Paul Hammond (citypaul) <paul@packsoftware.co.uk>",
   "license": "MIT",


### PR DESCRIPTION
## Summary

Fix version drift between internal and published packages by adding all packages to the changesets fixed group.

### Problem

The previous release (0.1.15) did not update `@scenarist/core` and `@scenarist/msw-adapter` because they were not in the changesets `fixed` group:

| Package | npm Version | Should Be |
|---------|-------------|-----------|
| `@scenarist/core` | 0.1.3 | 0.1.15 |
| `@scenarist/msw-adapter` | 0.1.3 | 0.1.15 |
| `@scenarist/express-adapter` | 0.1.15 | 0.1.15 ✅ |
| `@scenarist/nextjs-adapter` | 0.1.15 | 0.1.15 ✅ |
| `@scenarist/playwright-helpers` | 0.1.15 | 0.1.15 ✅ |

### Solution

1. **Add internal packages to fixed group** in `.changeset/config.json`:
   ```json
   "fixed": [
     [
       "@scenarist/core",
       "@scenarist/msw-adapter",
       "@scenarist/express-adapter",
       "@scenarist/nextjs-adapter",
       "@scenarist/playwright-helpers"
     ]
   ]
   ```

2. **Bump internal package versions** to 0.1.15 to match published packages

3. **Create changeset** to release all packages together as 0.1.16

### After This Release

All packages will be at version 0.1.16 and will stay synchronized going forward:
- `@scenarist/core`: 0.1.16
- `@scenarist/msw-adapter`: 0.1.16
- `@scenarist/express-adapter`: 0.1.16
- `@scenarist/nextjs-adapter`: 0.1.16
- `@scenarist/playwright-helpers`: 0.1.16

## Test plan

- [x] All 305 core tests pass
- [x] All 100 msw-adapter tests pass
- [x] All adapter tests pass
- [x] Build succeeds for all packages
- [x] Verified all package.json versions are now 0.1.15

🤖 Generated with [Claude Code](https://claude.com/claude-code)