### PR TITLE
feat(express-example): add state-aware mocking E2E tests (ADR-0019)

### DIFF
--- a/apps/express-example/src/app.ts
+++ b/apps/express-example/src/app.ts
@@ -12,6 +12,7 @@ import { setupStringMatchingRoutes } from "./routes/string-matching.js";
 import { setupUrlMatchingRoutes } from "./routes/url-matching.js";
 import { setupHostnameMatchingRoutes } from "./routes/hostname-matching.js";
 import { setupProductsRepoRoutes } from "./routes/products-repo.js";
+import { setupStateAwareRoutes } from "./routes/state-aware.js";
 import { scenarios } from "./scenarios.js";
 
 /**
@@ -68,6 +69,7 @@ export const createApp = (): {
   setupUrlMatchingRoutes(router);
   setupHostnameMatchingRoutes(router);
   setupProductsRepoRoutes(router);
+  setupStateAwareRoutes(router);
   app.use(router);
 
   // Health check endpoint

--- a/apps/express-example/src/routes/state-aware.ts
+++ b/apps/express-example/src/routes/state-aware.ts
@@ -1,0 +1,167 @@
+import type { Request, Response, Router } from "express";
+
+/**
+ * State-Aware Mocking Routes (ADR-0019)
+ *
+ * Demonstrates the three state-aware mocking capabilities:
+ * 1. stateResponse - Conditional responses based on current state
+ * 2. afterResponse.setState - Mutate state after returning a response
+ * 3. match.state - Select mocks based on current state
+ *
+ * These routes call external APIs which MSW intercepts via Scenarist.
+ */
+
+const LOAN_API_URL = "https://api.loans.com";
+const FEATURES_API_URL = "https://api.features.com";
+const PRICING_API_URL = "https://api.pricing.com";
+
+export const setupStateAwareRoutes = (router: Router): void => {
+  /**
+   * GET /api/loan/status
+   *
+   * Returns loan application status. Uses stateResponse to return
+   * different responses based on workflow state.
+   */
+  router.get("/api/loan/status", async (_req: Request, res: Response) => {
+    try {
+      const response = await fetch(`${LOAN_API_URL}/loan/status`);
+      const data = await response.json();
+
+      if (!response.ok) {
+        return res.status(response.status).json(data);
+      }
+
+      return res.json(data);
+    } catch (error) {
+      return res.status(500).json({
+        error: "Failed to get loan status",
+        message: error instanceof Error ? error.message : "Unknown error",
+      });
+    }
+  });
+
+  /**
+   * POST /api/loan/submit
+   *
+   * Submits a loan application. Uses afterResponse.setState to
+   * advance the workflow state to "submitted".
+   */
+  router.post("/api/loan/submit", async (req: Request, res: Response) => {
+    const { amount } = req.body;
+
+    if (!amount || amount <= 0) {
+      return res.status(400).json({
+        error: "Invalid request",
+        message: "Valid amount is required",
+      });
+    }
+
+    try {
+      const response = await fetch(`${LOAN_API_URL}/loan/submit`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ amount }),
+      });
+      const data = await response.json();
+
+      if (!response.ok) {
+        return res.status(response.status).json(data);
+      }
+
+      return res.json(data);
+    } catch (error) {
+      return res.status(500).json({
+        error: "Failed to submit loan application",
+        message: error instanceof Error ? error.message : "Unknown error",
+      });
+    }
+  });
+
+  /**
+   * POST /api/loan/review
+   *
+   * Completes loan review. Uses afterResponse.setState to
+   * advance the workflow state to "reviewed".
+   */
+  router.post("/api/loan/review", async (_req: Request, res: Response) => {
+    try {
+      const response = await fetch(`${LOAN_API_URL}/loan/review`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+      });
+      const data = await response.json();
+
+      if (!response.ok) {
+        return res.status(response.status).json(data);
+      }
+
+      return res.json(data);
+    } catch (error) {
+      return res.status(500).json({
+        error: "Failed to complete loan review",
+        message: error instanceof Error ? error.message : "Unknown error",
+      });
+    }
+  });
+
+  /**
+   * POST /api/features
+   *
+   * Sets a feature flag. Uses captureState to store the
+   * feature flag value in test state.
+   */
+  router.post("/api/features", async (req: Request, res: Response) => {
+    const { flag, enabled } = req.body;
+
+    if (!flag || enabled === undefined) {
+      return res.status(400).json({
+        error: "Invalid request",
+        message: "flag and enabled are required",
+      });
+    }
+
+    try {
+      const response = await fetch(`${FEATURES_API_URL}/features`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ flag, enabled }),
+      });
+      const data = await response.json();
+
+      if (!response.ok) {
+        return res.status(response.status).json(data);
+      }
+
+      return res.json(data);
+    } catch (error) {
+      return res.status(500).json({
+        error: "Failed to set feature flag",
+        message: error instanceof Error ? error.message : "Unknown error",
+      });
+    }
+  });
+
+  /**
+   * GET /api/pricing
+   *
+   * Returns pricing information. Uses match.state to select
+   * the appropriate mock based on feature flag state.
+   */
+  router.get("/api/pricing", async (_req: Request, res: Response) => {
+    try {
+      const response = await fetch(`${PRICING_API_URL}/pricing`);
+      const data = await response.json();
+
+      if (!response.ok) {
+        return res.status(response.status).json(data);
+      }
+
+      return res.json(data);
+    } catch (error) {
+      return res.status(500).json({
+        error: "Failed to get pricing",
+        message: error instanceof Error ? error.message : "Unknown error",
+      });
+    }
+  });
+};

--- a/apps/express-example/src/scenarios.ts
+++ b/apps/express-example/src/scenarios.ts
@@ -1308,6 +1308,163 @@ export const hostnameMatchingScenario: ScenaristScenario = {
 };
 
 /**
+ * Loan Application Workflow (ADR-0019 - State-Aware Mocking)
+ *
+ * Demonstrates:
+ * - stateResponse: Different responses based on current state (state.step)
+ * - afterResponse.setState: Advancing workflow state after response
+ *
+ * Flow:
+ * 1. Initial: GET /loan/status → "pending" (no state)
+ * 2. POST /loan/submit → sets state.step = "submitted"
+ * 3. GET /loan/status → "reviewing" (matches step = "submitted")
+ * 4. POST /loan/review → sets state.step = "reviewed"
+ * 5. GET /loan/status → "approved" (matches step = "reviewed")
+ */
+export const loanApplicationScenario: ScenaristScenario = {
+  id: "loanApplication",
+  name: "Loan Application Workflow",
+  description:
+    "State-aware loan workflow with stateResponse and afterResponse.setState",
+  mocks: [
+    // GET /loan/status - Returns different responses based on workflow state
+    {
+      method: "GET",
+      url: "https://api.loans.com/loan/status",
+      stateResponse: {
+        default: {
+          status: 200,
+          body: {
+            status: "pending",
+            message: "Application not yet submitted",
+          },
+        },
+        conditions: [
+          {
+            when: { step: "submitted" },
+            then: {
+              status: 200,
+              body: {
+                status: "reviewing",
+                message: "Application under review",
+              },
+            },
+          },
+          {
+            when: { step: "reviewed" },
+            then: {
+              status: 200,
+              body: {
+                status: "approved",
+                message: "Application approved",
+              },
+            },
+          },
+        ],
+      },
+    },
+    // POST /loan/submit - Sets state.step = "submitted"
+    {
+      method: "POST",
+      url: "https://api.loans.com/loan/submit",
+      response: {
+        status: 200,
+        body: {
+          success: true,
+          message: "Application submitted successfully",
+        },
+      },
+      afterResponse: {
+        setState: { step: "submitted" },
+      },
+    },
+    // POST /loan/review - Sets state.step = "reviewed"
+    {
+      method: "POST",
+      url: "https://api.loans.com/loan/review",
+      response: {
+        status: 200,
+        body: {
+          success: true,
+          message: "Review completed",
+        },
+      },
+      afterResponse: {
+        setState: { step: "reviewed" },
+      },
+    },
+  ],
+};
+
+/**
+ * Feature Flags Scenario (ADR-0019 - State-Aware Mocking)
+ *
+ * Demonstrates:
+ * - match.state: Selecting different mocks based on feature flag state
+ * - captureState: Capturing feature flag value from request body
+ *
+ * Unlike stateResponse (one mock, many responses), match.state selects
+ * WHICH mock handles the request based on current state.
+ *
+ * Flow:
+ * 1. Initial: GET /pricing → standard pricing (no feature flag)
+ * 2. POST /features → captures state.premiumEnabled = true
+ * 3. GET /pricing → premium pricing (match.state selects premium mock)
+ */
+export const featureFlagsScenario: ScenaristScenario = {
+  id: "featureFlags",
+  name: "Feature Flags",
+  description: "State-based mock selection with match.state",
+  mocks: [
+    // POST /features - Captures feature flag state
+    // Note: Using simple key "premiumEnabled" instead of dot-notation
+    // because state keys are treated as literal strings
+    {
+      method: "POST",
+      url: "https://api.features.com/features",
+      captureState: {
+        premiumEnabled: "body.enabled",
+      },
+      response: {
+        status: 200,
+        body: {
+          success: true,
+          message: "Feature flag updated",
+        },
+      },
+    },
+    // GET /pricing with premium feature flag enabled (match.state)
+    {
+      method: "GET",
+      url: "https://api.pricing.com/pricing",
+      match: {
+        state: { premiumEnabled: true },
+      },
+      response: {
+        status: 200,
+        body: {
+          tier: "premium",
+          price: 50,
+          discount: "50% off",
+        },
+      },
+    },
+    // GET /pricing fallback (standard pricing, no feature flag)
+    {
+      method: "GET",
+      url: "https://api.pricing.com/pricing",
+      response: {
+        status: 200,
+        body: {
+          tier: "standard",
+          price: 100,
+        },
+      },
+    },
+  ],
+};
+
+/**
  * Premium User Scenario - Repository Pattern Integration
  *
  * NOTE: This scenario demonstrates the COMBINED testing strategy:
@@ -1374,4 +1531,6 @@ export const scenarios = {
   urlMatching: urlMatchingScenario,
   hostnameMatching: hostnameMatchingScenario,
   premiumUser: premiumUserScenario,
+  loanApplication: loanApplicationScenario,
+  featureFlags: featureFlagsScenario,
 } as const satisfies ScenaristScenarios;

--- a/apps/express-example/tests/state-aware-mocking.test.ts
+++ b/apps/express-example/tests/state-aware-mocking.test.ts
@@ -1,0 +1,207 @@
+import { SCENARIST_TEST_ID_HEADER } from "@scenarist/express-adapter";
+import request from "supertest";
+import { afterAll, describe, expect, it } from "vitest";
+
+import { createTestFixtures } from "./test-helpers.js";
+const fixtures = createTestFixtures();
+
+/**
+ * State-Aware Mocking E2E Tests (ADR-0019)
+ *
+ * Tests the three new state-aware mocking capabilities:
+ * 1. stateResponse - Conditional responses based on current state
+ * 2. afterResponse.setState - Mutate state after returning a response
+ * 3. match.state - Select mocks based on current state
+ *
+ * These features enable state machine patterns where mock behavior
+ * changes based on accumulated state from previous requests.
+ */
+describe("State-Aware Mocking E2E (ADR-0019)", () => {
+  afterAll(async () => {
+    await fixtures.cleanup();
+  });
+
+  describe("Loan Application Workflow - stateResponse + afterResponse.setState", () => {
+    /**
+     * This test demonstrates a loan application workflow where:
+     * 1. GET /loan/status returns state-dependent responses
+     * 2. POST /loan/submit advances the workflow state via afterResponse.setState
+     *
+     * Flow:
+     * - Initial: status returns "pending" (no state)
+     * - After submit: status returns "reviewing" (state.step = "submitted")
+     * - After review: status returns "approved" (state.step = "reviewed")
+     */
+    it("should return different responses based on workflow state", async () => {
+      await request(fixtures.app)
+        .post(fixtures.scenarist.config.endpoints.setScenario)
+        .set(SCENARIST_TEST_ID_HEADER, "loan-workflow-1")
+        .send({ scenario: "loanApplication" });
+
+      // Initial state - no step set, returns default "pending"
+      const status1 = await request(fixtures.app)
+        .get("/api/loan/status")
+        .set(SCENARIST_TEST_ID_HEADER, "loan-workflow-1");
+
+      expect(status1.status).toBe(200);
+      expect(status1.body.status).toBe("pending");
+      expect(status1.body.message).toBe("Application not yet submitted");
+
+      // Submit application - sets state.step = "submitted" via afterResponse.setState
+      const submit = await request(fixtures.app)
+        .post("/api/loan/submit")
+        .set(SCENARIST_TEST_ID_HEADER, "loan-workflow-1")
+        .send({ amount: 10000 });
+
+      expect(submit.status).toBe(200);
+      expect(submit.body.success).toBe(true);
+
+      // After submit - stateResponse condition matches step = "submitted"
+      const status2 = await request(fixtures.app)
+        .get("/api/loan/status")
+        .set(SCENARIST_TEST_ID_HEADER, "loan-workflow-1");
+
+      expect(status2.status).toBe(200);
+      expect(status2.body.status).toBe("reviewing");
+      expect(status2.body.message).toBe("Application under review");
+
+      // Review completes - sets state.step = "reviewed"
+      const review = await request(fixtures.app)
+        .post("/api/loan/review")
+        .set(SCENARIST_TEST_ID_HEADER, "loan-workflow-1");
+
+      expect(review.status).toBe(200);
+
+      // After review - stateResponse condition matches step = "reviewed"
+      const status3 = await request(fixtures.app)
+        .get("/api/loan/status")
+        .set(SCENARIST_TEST_ID_HEADER, "loan-workflow-1");
+
+      expect(status3.status).toBe(200);
+      expect(status3.body.status).toBe("approved");
+      expect(status3.body.message).toBe("Application approved");
+    });
+  });
+
+  describe("Feature Flags - match.state for mock selection", () => {
+    /**
+     * This test demonstrates using match.state to select different mocks
+     * based on feature flag state. Different from stateResponse (one mock,
+     * many responses), match.state selects WHICH mock handles the request.
+     *
+     * Flow:
+     * - Set feature flag via POST /features
+     * - GET /api/pricing returns different mock based on feature state
+     */
+    it("should select different mocks based on feature flag state", async () => {
+      await request(fixtures.app)
+        .post(fixtures.scenarist.config.endpoints.setScenario)
+        .set(SCENARIST_TEST_ID_HEADER, "feature-flag-1")
+        .send({ scenario: "featureFlags" });
+
+      // Initial state - no feature flags, returns standard pricing
+      const pricing1 = await request(fixtures.app)
+        .get("/api/pricing")
+        .set(SCENARIST_TEST_ID_HEADER, "feature-flag-1");
+
+      expect(pricing1.status).toBe(200);
+      expect(pricing1.body.tier).toBe("standard");
+      expect(pricing1.body.price).toBe(100);
+
+      // Enable premium feature flag
+      const enableFlag = await request(fixtures.app)
+        .post("/api/features")
+        .set(SCENARIST_TEST_ID_HEADER, "feature-flag-1")
+        .send({ flag: "premium_pricing", enabled: true });
+
+      expect(enableFlag.status).toBe(200);
+      expect(enableFlag.body).toEqual({
+        success: true,
+        message: "Feature flag updated",
+      });
+
+      // Now pricing returns premium tier (mock selected via match.state)
+      const pricing2 = await request(fixtures.app)
+        .get("/api/pricing")
+        .set(SCENARIST_TEST_ID_HEADER, "feature-flag-1");
+
+      expect(pricing2.status).toBe(200);
+      expect(pricing2.body.tier).toBe("premium");
+      expect(pricing2.body.price).toBe(50);
+    });
+  });
+
+  describe("State Isolation - Different test IDs have independent state", () => {
+    it("should maintain independent workflow state for different test IDs", async () => {
+      // Set up both tests with same scenario
+      await request(fixtures.app)
+        .post(fixtures.scenarist.config.endpoints.setScenario)
+        .set(SCENARIST_TEST_ID_HEADER, "isolation-A")
+        .send({ scenario: "loanApplication" });
+
+      await request(fixtures.app)
+        .post(fixtures.scenarist.config.endpoints.setScenario)
+        .set(SCENARIST_TEST_ID_HEADER, "isolation-B")
+        .send({ scenario: "loanApplication" });
+
+      // Test A submits application
+      await request(fixtures.app)
+        .post("/api/loan/submit")
+        .set(SCENARIST_TEST_ID_HEADER, "isolation-A")
+        .send({ amount: 10000 });
+
+      // Test A should be "reviewing"
+      const statusA = await request(fixtures.app)
+        .get("/api/loan/status")
+        .set(SCENARIST_TEST_ID_HEADER, "isolation-A");
+
+      expect(statusA.body.status).toBe("reviewing");
+
+      // Test B should still be "pending" (independent state)
+      const statusB = await request(fixtures.app)
+        .get("/api/loan/status")
+        .set(SCENARIST_TEST_ID_HEADER, "isolation-B");
+
+      expect(statusB.body.status).toBe("pending");
+    });
+  });
+
+  describe("State Reset on Scenario Switch", () => {
+    it("should reset state-aware workflow when switching scenarios", async () => {
+      await request(fixtures.app)
+        .post(fixtures.scenarist.config.endpoints.setScenario)
+        .set(SCENARIST_TEST_ID_HEADER, "reset-test")
+        .send({ scenario: "loanApplication" });
+
+      // Advance to "reviewing" state
+      await request(fixtures.app)
+        .post("/api/loan/submit")
+        .set(SCENARIST_TEST_ID_HEADER, "reset-test")
+        .send({ amount: 10000 });
+
+      const status1 = await request(fixtures.app)
+        .get("/api/loan/status")
+        .set(SCENARIST_TEST_ID_HEADER, "reset-test");
+
+      expect(status1.body.status).toBe("reviewing");
+
+      // Switch to different scenario and back
+      await request(fixtures.app)
+        .post(fixtures.scenarist.config.endpoints.setScenario)
+        .set(SCENARIST_TEST_ID_HEADER, "reset-test")
+        .send({ scenario: "success" });
+
+      await request(fixtures.app)
+        .post(fixtures.scenarist.config.endpoints.setScenario)
+        .set(SCENARIST_TEST_ID_HEADER, "reset-test")
+        .send({ scenario: "loanApplication" });
+
+      // State should be reset - back to "pending"
+      const status2 = await request(fixtures.app)
+        .get("/api/loan/status")
+        .set(SCENARIST_TEST_ID_HEADER, "reset-test");
+
+      expect(status2.body.status).toBe("pending");
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Add comprehensive E2E tests demonstrating ADR-0019 state-aware mocking features in the Express example app
- Add `loanApplicationScenario` testing `stateResponse` with conditions and `afterResponse.setState` for multi-step workflow state transitions
- Add `featureFlagsScenario` testing `match.state` for mock selection and `captureState` for capturing values from request body

## Features Tested

### Loan Application Workflow (`stateResponse` + `afterResponse.setState`)
- GET `/api/loan/status` returns different responses based on workflow state:
  - Initial: "pending" (no state)
  - After submit: "reviewing" (state.step = "submitted")
  - After review: "approved" (state.step = "reviewed")
- POST `/api/loan/submit` advances state via `afterResponse.setState`
- POST `/api/loan/review` advances state via `afterResponse.setState`

### Feature Flags (`match.state` + `captureState`)
- POST `/api/features` captures feature flag value from request body into state
- GET `/api/pricing` uses `match.state` to select appropriate mock:
  - Standard pricing (no feature flag)
  - Premium pricing (when `premiumEnabled: true`)

### Additional Coverage
- State isolation between different test IDs
- State reset when switching scenarios

## Test plan

- [x] All 4 new state-aware mocking E2E tests pass
- [x] Full Express example test suite passes (89 tests)
- [x] TypeScript typecheck passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)