### PR TITLE
fix(ci): trigger CI on Version PR after changesets push

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -71,6 +71,29 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.RELEASE_PAT }}
           NPM_CONFIG_PROVENANCE: true
 
+      # When changesets creates/updates a Version PR, the push doesn't trigger CI
+      # because GITHUB_TOKEN (even PATs) don't trigger workflows on pushes by default.
+      # Close/reopen the PR to trigger CI on the new commit.
+      # @see https://docs.github.com/en/actions/security-guides/automatic-token-authentication#using-the-github_token-in-a-workflow
+      - name: Trigger CI on Version PR
+        if: steps.changesets.outputs.hasChangesets == 'true' && steps.changesets.outputs.published != 'true'
+        env:
+          GH_TOKEN: ${{ secrets.RELEASE_PAT }}
+        run: |
+          echo "Version PR created/updated - triggering CI..."
+
+          # Find the Version PR by branch name
+          PR_NUMBER=$(gh pr list --head changeset-release/main --json number --jq '.[0].number')
+
+          if [ -n "$PR_NUMBER" ]; then
+            echo "Found Version PR #$PR_NUMBER, closing and reopening to trigger CI..."
+            gh pr close "$PR_NUMBER"
+            gh pr reopen "$PR_NUMBER"
+            echo "✅ CI triggered on Version PR #$PR_NUMBER"
+          else
+            echo "⚠️ No Version PR found on branch changeset-release/main"
+          fi
+
       # SBOM generation only runs after successful publish
       - name: Generate SBOM
         if: steps.changesets.outputs.published == 'true'


### PR DESCRIPTION
## Summary

- Fixes the issue where Version PRs (created by changesets) don't run CI checks
- The root cause: GitHub Actions using tokens don't trigger workflows on push by default
- The fix: Close and reopen the Version PR after changesets runs to trigger CI

## Problem

When the changesets action creates or updates the Version PR:
1. It pushes to `changeset-release/main` branch
2. This push **should** trigger CI, but doesn't
3. The Version PR sits without CI checks, blocking merge

This happens because GitHub prevents token-authenticated pushes from triggering workflows (to prevent infinite loops).

## Solution

After changesets runs, if a Version PR was created/updated (not published), we:
1. Find the Version PR by branch name
2. Close and reopen it
3. This triggers the CI workflow on the new commit

## Test plan

- [ ] Merge this PR
- [ ] Wait for next changesets update to Version PR #312
- [ ] Verify CI runs automatically on the Version PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)