### PR TITLE
fix(msw-adapter): active scenario with fallback mock overrides default mocks

### DIFF
--- a/.changeset/fix-scenario-switching.md
+++ b/.changeset/fix-scenario-switching.md
@@ -1,0 +1,25 @@
+---
+"@scenarist/msw-adapter": patch
+---
+
+fix: correct scenario switching priority when active scenario has fallback mock
+
+When switching from the default scenario to a different scenario, mocks from the
+active scenario now correctly take precedence over default scenario mocks.
+
+Previously, if the default scenario had a sequence mock (specificity 1) and the
+active scenario had a simple response mock (specificity 0), the default mock
+would incorrectly win due to higher specificity. This violated user expectations
+that switching to a scenario should use that scenario's mocks.
+
+The fix changes mock selection priority:
+
+1. If no active scenario is set → use default scenario mocks
+2. If active scenario has a fallback mock (no match criteria) → use ONLY active mocks
+3. If active scenario has only conditional mocks → include default as backup
+
+A "fallback mock" is one without match criteria - it always matches if URL+method
+match. When an active scenario explicitly covers an endpoint with a fallback mock,
+default scenario mocks for that endpoint are now excluded.
+
+Closes #335

--- a/apps/express-example/src/scenarios.ts
+++ b/apps/express-example/src/scenarios.ts
@@ -1426,6 +1426,49 @@ export const loanApplicationScenario: ScenaristScenario = {
 };
 
 /**
+ * BUG FIX: Issue #335 - Simple response should override default sequence
+ *
+ * This scenario tests that when switching to a scenario with a SIMPLE response
+ * mock for an endpoint that has a SEQUENCE mock in default, the simple response
+ * is used instead of the default sequence.
+ *
+ * Setup:
+ * - Default scenario has SEQUENCE mock for GET /applications/:id
+ *   (returns { state: 'appStarted', source: 'default-sequence' })
+ *
+ * - This scenario has SIMPLE RESPONSE mock for same endpoint
+ *   (returns { state: 'ready', source: 'issue335-simple-response' })
+ *
+ * Expected behavior:
+ * 1. Switch to issue335-simple-response scenario
+ * 2. GET /applications/:id → should return simple response:
+ *    { state: 'ready', source: 'issue335-simple-response' }
+ *
+ * @see https://github.com/citypaul/scenarist/issues/335
+ */
+export const issue335SimpleResponseScenario: ScenaristScenario = {
+  id: "issue335-simple-response",
+  name: "Issue #335 - Simple Response Override",
+  description:
+    "Simple response mock that should override default sequence mock",
+  mocks: [
+    // GET /applications/:id - Simple response
+    // This mock should be selected OVER default's sequence mock
+    {
+      method: "GET",
+      url: "https://api.issue328.com/applications/:id",
+      response: {
+        status: 200,
+        body: {
+          state: "ready",
+          source: "issue335-simple-response",
+        },
+      },
+    },
+  ],
+};
+
+/**
  * BUG REPRODUCTION: Issue #328 - Active scenario with stateResponse
  *
  * This is the ACTIVE scenario that should override the default sequence.
@@ -1636,4 +1679,6 @@ export const scenarios = {
   featureFlags: featureFlagsScenario,
   // Issue #328 Bug Reproduction - stateResponse should override default sequence
   "issue328-stateresponse": issue328StateResponseScenario,
+  // Issue #335 Bug Fix - simple response should override default sequence
+  "issue335-simple-response": issue335SimpleResponseScenario,
 } as const satisfies ScenaristScenarios;

--- a/apps/express-example/tests/issue-335-simple-response-override.test.ts
+++ b/apps/express-example/tests/issue-335-simple-response-override.test.ts
@@ -1,0 +1,77 @@
+import { SCENARIST_TEST_ID_HEADER } from "@scenarist/express-adapter";
+import request from "supertest";
+import { afterAll, describe, expect, it } from "vitest";
+
+import { createTestFixtures } from "./test-helpers.js";
+
+const fixtures = createTestFixtures();
+
+/**
+ * Issue #335: Scenario switching must use active scenario's response
+ *
+ * When switching to a scenario, that scenario's mocks must take precedence
+ * over default scenario mocks for the same endpoint - regardless of specificity.
+ *
+ * @see https://github.com/citypaul/scenarist/issues/335
+ */
+describe("Issue #335: Active scenario simple response overrides default sequence", () => {
+  afterAll(async () => {
+    await fixtures.cleanup();
+  });
+
+  it("returns active scenario's simple response instead of default's sequence mock", async () => {
+    const testId = "issue335-simple-response-wins";
+
+    await request(fixtures.app)
+      .post(fixtures.scenarist.config.endpoints.setScenario)
+      .set(SCENARIST_TEST_ID_HEADER, testId)
+      .send({ scenario: "issue335-simple-response" });
+
+    const response = await request(fixtures.app)
+      .get("/api/issue328/applications/app-123")
+      .set(SCENARIST_TEST_ID_HEADER, testId);
+
+    expect(response.status).toBe(200);
+    expect(response.body).toEqual({
+      state: "ready",
+      source: "issue335-simple-response",
+    });
+  });
+
+  it("uses default sequence when no scenario is set", async () => {
+    const testId = "issue335-default-still-works";
+
+    const response = await request(fixtures.app)
+      .get("/api/issue328/applications/app-456")
+      .set(SCENARIST_TEST_ID_HEADER, testId);
+
+    expect(response.status).toBe(200);
+    expect(response.body.source).toBe("default-sequence");
+  });
+
+  it("resumes default sequence after switching back from active scenario", async () => {
+    const testId = "issue335-switch-back";
+
+    await request(fixtures.app)
+      .post(fixtures.scenarist.config.endpoints.setScenario)
+      .set(SCENARIST_TEST_ID_HEADER, testId)
+      .send({ scenario: "issue335-simple-response" });
+
+    const firstResponse = await request(fixtures.app)
+      .get("/api/issue328/applications/app-789")
+      .set(SCENARIST_TEST_ID_HEADER, testId);
+
+    expect(firstResponse.body.source).toBe("issue335-simple-response");
+
+    await request(fixtures.app)
+      .post(fixtures.scenarist.config.endpoints.setScenario)
+      .set(SCENARIST_TEST_ID_HEADER, testId)
+      .send({ scenario: "default" });
+
+    const secondResponse = await request(fixtures.app)
+      .get("/api/issue328/applications/app-789")
+      .set(SCENARIST_TEST_ID_HEADER, testId);
+
+    expect(secondResponse.body.source).toBe("default-sequence");
+  });
+});

--- a/apps/nextjs-app-router-example/app/api/issue335/applications/[id]/route.ts
+++ b/apps/nextjs-app-router-example/app/api/issue335/applications/[id]/route.ts
@@ -1,0 +1,50 @@
+/**
+ * Issue #335 Test API Route
+ *
+ * Fetches application status from external API (json-server).
+ * Used to verify that switching to a scenario with a simple response
+ * overrides the default scenario's sequence mock.
+ *
+ * @see https://github.com/citypaul/scenarist/issues/335
+ */
+
+import { NextRequest, NextResponse } from "next/server";
+
+import { getScenaristHeaders } from "@scenarist/nextjs-adapter/app";
+
+type RouteContext = {
+  params: Promise<{ id: string }>;
+};
+
+export async function GET(request: NextRequest, context: RouteContext) {
+  try {
+    const { id } = await context.params;
+
+    const response = await fetch(
+      `http://localhost:3001/issue335/applications/${id}`,
+      {
+        headers: {
+          ...getScenaristHeaders(request),
+        },
+      },
+    );
+
+    if (!response.ok) {
+      throw new Error(`External API error: ${response.status}`);
+    }
+
+    const data = await response.json();
+
+    return NextResponse.json(data);
+  } catch (error) {
+    return NextResponse.json(
+      {
+        error:
+          error instanceof Error
+            ? error.message
+            : "Failed to fetch application status",
+      },
+      { status: 500 },
+    );
+  }
+}

--- a/apps/nextjs-app-router-example/app/issue335/page.tsx
+++ b/apps/nextjs-app-router-example/app/issue335/page.tsx
@@ -1,0 +1,112 @@
+/**
+ * Issue #335 Test Page - React Server Component
+ *
+ * Demonstrates testing scenario switching behavior where an active scenario's
+ * simple response should override the default scenario's sequence mock.
+ *
+ * This is a SERVER component that fetches data on each request.
+ * The test navigates to this page and verifies the response displayed.
+ *
+ * @see https://github.com/citypaul/scenarist/issues/335
+ */
+
+import { headers } from "next/headers";
+import { getScenaristHeadersFromReadonlyHeaders } from "@scenarist/nextjs-adapter/app";
+
+type ApplicationStatus = {
+  readonly state: string;
+  readonly source: string;
+  readonly sequenceIndex?: number;
+};
+
+async function fetchApplicationStatus(
+  appId: string,
+): Promise<ApplicationStatus> {
+  const headersList = await headers();
+
+  const response = await fetch(
+    `http://localhost:3002/api/issue335/applications/${appId}`,
+    {
+      headers: {
+        ...getScenaristHeadersFromReadonlyHeaders(headersList),
+      },
+      cache: "no-store", // Disable caching for tests
+    },
+  );
+
+  if (!response.ok) {
+    throw new Error(
+      `Failed to fetch application status: ${response.statusText}`,
+    );
+  }
+
+  return response.json();
+}
+
+type PageProps = {
+  searchParams: Promise<{ appId?: string }>;
+};
+
+export default async function Issue335Page({ searchParams }: PageProps) {
+  const { appId = `app-${Date.now()}` } = await searchParams;
+  const status = await fetchApplicationStatus(appId);
+
+  return (
+    <div className="min-h-screen bg-gray-50 py-12 px-4">
+      <div className="max-w-2xl mx-auto">
+        <h1 className="text-3xl font-bold text-gray-900 mb-6">
+          Issue #335: Scenario Switching Test
+        </h1>
+
+        <p className="text-gray-600 mb-8">
+          This page tests that switching to an active scenario with a simple
+          response correctly overrides the default scenario&apos;s sequence
+          mock.
+        </p>
+
+        <div
+          role="status"
+          aria-live="polite"
+          className="bg-white shadow rounded-lg p-6"
+        >
+          <h2 className="text-xl font-semibold text-gray-800 mb-4">
+            Application Status
+          </h2>
+          <dl className="space-y-3">
+            <div className="flex justify-between">
+              <dt className="text-gray-600">State:</dt>
+              <dd className="font-medium text-gray-900">{status.state}</dd>
+            </div>
+            <div className="flex justify-between">
+              <dt className="text-gray-600">Source:</dt>
+              <dd className="font-medium text-gray-900">{status.source}</dd>
+            </div>
+            {status.sequenceIndex !== undefined && (
+              <div className="flex justify-between">
+                <dt className="text-gray-600">Sequence Index:</dt>
+                <dd className="font-medium text-gray-900">
+                  {status.sequenceIndex}
+                </dd>
+              </div>
+            )}
+          </dl>
+        </div>
+
+        <div className="mt-8 text-sm text-gray-500">
+          <h3 className="font-medium text-gray-700 mb-2">Expected Behavior:</h3>
+          <ul className="list-disc pl-5 space-y-1">
+            <li>
+              <strong>Default scenario:</strong> Returns sequence response with
+              source &quot;default-sequence&quot;
+            </li>
+            <li>
+              <strong>issue335SimpleResponse scenario:</strong> Returns simple
+              response with source &quot;issue335-simple-response&quot; and
+              state &quot;ready&quot;
+            </li>
+          </ul>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/nextjs-app-router-example/lib/scenarios.ts
+++ b/apps/nextjs-app-router-example/lib/scenarios.ts
@@ -23,6 +23,34 @@ export const defaultScenario: ScenaristScenario = {
   name: "Default Scenario",
   description: "Default baseline behavior with happy path mocks",
   mocks: [
+    // Issue #335 BUG FIX: Sequence mock in default scenario
+    // This mock should be OVERRIDDEN by simple response in issue335-simple-response scenario
+    // @see https://github.com/citypaul/scenarist/issues/335
+    {
+      method: "GET",
+      url: "http://localhost:3001/issue335/applications/:id",
+      sequence: {
+        responses: [
+          {
+            status: 200,
+            body: {
+              state: "appStarted",
+              source: "default-sequence",
+              sequenceIndex: 0,
+            },
+          },
+          {
+            status: 200,
+            body: {
+              state: "appStarted",
+              source: "default-sequence",
+              sequenceIndex: 1,
+            },
+          },
+        ],
+        repeat: "last",
+      },
+    },
     // Products API - standard tier pricing (most common case)
     {
       method: "GET",
@@ -1154,6 +1182,35 @@ export const featureFlagsScenario: ScenaristScenario = {
 };
 
 /**
+ * Issue #335 BUG FIX: Simple response should override default sequence
+ *
+ * This scenario tests that when switching to a scenario with a SIMPLE response
+ * mock for an endpoint that has a SEQUENCE mock in default, the simple response
+ * is used instead of the default sequence.
+ *
+ * @see https://github.com/citypaul/scenarist/issues/335
+ */
+export const issue335SimpleResponseScenario: ScenaristScenario = {
+  id: "issue335SimpleResponse",
+  name: "Issue #335 - Simple Response Override",
+  description:
+    "Simple response mock that should override default sequence mock",
+  mocks: [
+    {
+      method: "GET",
+      url: "http://localhost:3001/issue335/applications/:id",
+      response: {
+        status: 200,
+        body: {
+          state: "ready",
+          source: "issue335-simple-response",
+        },
+      },
+    },
+  ],
+};
+
+/**
  * All scenarios for registration and type-safe access
  */
 export const scenarios = {
@@ -1171,5 +1228,6 @@ export const scenarios = {
   hostnameMatching: hostnameMatchingScenario,
   loanApplication: loanApplicationScenario,
   featureFlags: featureFlagsScenario,
+  issue335SimpleResponse: issue335SimpleResponseScenario,
   ...checkoutScenarios,
 } as const satisfies ScenaristScenarios;

--- a/apps/nextjs-app-router-example/tests/playwright/issue-335-scenario-switching.spec.ts
+++ b/apps/nextjs-app-router-example/tests/playwright/issue-335-scenario-switching.spec.ts
@@ -1,0 +1,62 @@
+/**
+ * Issue #335: Active scenario simple response overrides default sequence
+ *
+ * When switching to a scenario, that scenario's mocks must take precedence
+ * over default scenario mocks for the same endpoint - regardless of specificity.
+ *
+ * @see https://github.com/citypaul/scenarist/issues/335
+ */
+
+import { test, expect } from "./fixtures";
+
+test.describe("Issue #335: Active scenario simple response overrides default sequence", () => {
+  test("returns active scenario's simple response instead of default's sequence mock", async ({
+    page,
+    switchScenario,
+  }) => {
+    await switchScenario(page, "issue335SimpleResponse");
+
+    // Server component fetches data on navigation - no button click needed
+    await page.goto("/issue335");
+
+    // Verify the response shows the active scenario's simple response
+    const statusRegion = page.getByRole("status");
+    await expect(statusRegion).toContainText("ready");
+    await expect(statusRegion).toContainText("issue335-simple-response");
+  });
+
+  test("uses default sequence when no scenario is set", async ({
+    page,
+    switchScenario,
+  }) => {
+    // Switch to default scenario explicitly
+    await switchScenario(page, "default");
+
+    // Server component fetches data on navigation
+    await page.goto("/issue335");
+
+    // Verify the response shows the default scenario's sequence response
+    const statusRegion = page.getByRole("status");
+    await expect(statusRegion).toContainText("default-sequence");
+  });
+
+  test("resumes default sequence after switching back from active scenario", async ({
+    page,
+    switchScenario,
+  }) => {
+    // First, switch to the issue335 scenario
+    await switchScenario(page, "issue335SimpleResponse");
+    await page.goto("/issue335");
+
+    // Verify active scenario's response
+    const statusRegion = page.getByRole("status");
+    await expect(statusRegion).toContainText("issue335-simple-response");
+
+    // Switch back to default scenario
+    await switchScenario(page, "default");
+
+    // Navigate again to get the default scenario's response
+    await page.goto("/issue335");
+    await expect(statusRegion).toContainText("default-sequence");
+  });
+});

--- a/apps/nextjs-pages-router-example/lib/scenarios.ts
+++ b/apps/nextjs-pages-router-example/lib/scenarios.ts
@@ -21,6 +21,34 @@ export const defaultScenario: ScenaristScenario = {
   name: "Default Scenario",
   description: "Default baseline behavior with standard fallbacks",
   mocks: [
+    // Issue #335 BUG FIX: Sequence mock in default scenario
+    // This mock should be OVERRIDDEN by simple response in issue335-simple-response scenario
+    // @see https://github.com/citypaul/scenarist/issues/335
+    {
+      method: "GET",
+      url: "http://localhost:3001/issue335/applications/:id",
+      sequence: {
+        responses: [
+          {
+            status: 200,
+            body: {
+              state: "appStarted",
+              source: "default-sequence",
+              sequenceIndex: 0,
+            },
+          },
+          {
+            status: 200,
+            body: {
+              state: "appStarted",
+              source: "default-sequence",
+              sequenceIndex: 1,
+            },
+          },
+        ],
+        repeat: "last",
+      },
+    },
     // Products endpoint - fallback with standard pricing
     {
       method: "GET",
@@ -1121,6 +1149,35 @@ export const featureFlagsScenario: ScenaristScenario = {
 };
 
 /**
+ * Issue #335 BUG FIX: Simple response should override default sequence
+ *
+ * This scenario tests that when switching to a scenario with a SIMPLE response
+ * mock for an endpoint that has a SEQUENCE mock in default, the simple response
+ * is used instead of the default sequence.
+ *
+ * @see https://github.com/citypaul/scenarist/issues/335
+ */
+export const issue335SimpleResponseScenario: ScenaristScenario = {
+  id: "issue335SimpleResponse",
+  name: "Issue #335 - Simple Response Override",
+  description:
+    "Simple response mock that should override default sequence mock",
+  mocks: [
+    {
+      method: "GET",
+      url: "http://localhost:3001/issue335/applications/:id",
+      response: {
+        status: 200,
+        body: {
+          state: "ready",
+          source: "issue335-simple-response",
+        },
+      },
+    },
+  ],
+};
+
+/**
  * All scenarios for registration and type-safe access
  */
 export const scenarios = {
@@ -1138,4 +1195,5 @@ export const scenarios = {
   hostnameMatching: hostnameMatchingScenario,
   loanApplication: loanApplicationScenario,
   featureFlags: featureFlagsScenario,
+  issue335SimpleResponse: issue335SimpleResponseScenario,
 } as const satisfies ScenaristScenarios;

--- a/apps/nextjs-pages-router-example/pages/api/issue335/applications/[id].ts
+++ b/apps/nextjs-pages-router-example/pages/api/issue335/applications/[id].ts
@@ -1,0 +1,33 @@
+/**
+ * Issue #335 Test API Route
+ *
+ * Fetches application status from external API (json-server).
+ * Used to verify that switching to a scenario with a simple response
+ * overrides the default scenario's sequence mock.
+ *
+ * @see https://github.com/citypaul/scenarist/issues/335
+ */
+
+import type { NextApiRequest, NextApiResponse } from "next";
+import { getScenaristHeaders } from "@scenarist/nextjs-adapter/pages";
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse,
+) {
+  const { id } = req.query;
+
+  const encodedId = encodeURIComponent(Array.isArray(id) ? id[0] : (id ?? ""));
+
+  const response = await fetch(
+    `http://localhost:3001/issue335/applications/${encodedId}`,
+    {
+      headers: {
+        ...getScenaristHeaders(req),
+      },
+    },
+  );
+
+  const data = await response.json();
+  return res.status(response.status).json(data);
+}

--- a/apps/nextjs-pages-router-example/pages/issue335.tsx
+++ b/apps/nextjs-pages-router-example/pages/issue335.tsx
@@ -1,0 +1,152 @@
+/**
+ * Issue #335 Test Page
+ *
+ * Demonstrates testing scenario switching behavior where an active scenario's
+ * simple response should override the default scenario's sequence mock.
+ *
+ * @see https://github.com/citypaul/scenarist/issues/335
+ */
+
+import { useState } from "react";
+import { getScenaristHeaders } from "@scenarist/nextjs-adapter/pages";
+import type { GetServerSideProps } from "next";
+
+type ApplicationStatus = {
+  state: string;
+  source: string;
+  sequenceIndex?: number;
+};
+
+type PageProps = {
+  testIdHeader: Record<string, string>;
+};
+
+export const getServerSideProps: GetServerSideProps<PageProps> = async (
+  context,
+) => {
+  // Forward Scenarist headers for client-side fetches
+  const testIdHeader = getScenaristHeaders(context.req);
+
+  return {
+    props: {
+      testIdHeader,
+    },
+  };
+};
+
+export default function Issue335Page({ testIdHeader }: PageProps) {
+  const [status, setStatus] = useState<ApplicationStatus | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [callCount, setCallCount] = useState(0);
+
+  const checkStatus = async () => {
+    setLoading(true);
+    setError(null);
+
+    try {
+      const response = await fetch(
+        `/api/issue335/applications/app-${Date.now()}`,
+        {
+          headers: testIdHeader,
+        },
+      );
+
+      if (!response.ok) {
+        throw new Error(`API error: ${response.status}`);
+      }
+
+      const data = await response.json();
+      setStatus(data);
+      setCallCount((prev) => prev + 1);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Unknown error");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div className="min-h-screen bg-gray-50 py-12 px-4">
+      <div className="max-w-2xl mx-auto">
+        <h1 className="text-3xl font-bold text-gray-900 mb-6">
+          Issue #335: Scenario Switching Test
+        </h1>
+
+        <p className="text-gray-600 mb-8">
+          This page tests that switching to an active scenario with a simple
+          response correctly overrides the default scenario&apos;s sequence
+          mock.
+        </p>
+
+        <div className="bg-white shadow rounded-lg p-6 mb-6">
+          <button
+            onClick={checkStatus}
+            disabled={loading}
+            className="w-full bg-blue-600 text-white py-3 px-4 rounded-md hover:bg-blue-700 disabled:opacity-50 disabled:cursor-not-allowed font-medium"
+          >
+            {loading ? "Checking..." : "Check Application Status"}
+          </button>
+        </div>
+
+        {error && (
+          <div
+            role="alert"
+            className="bg-red-50 border border-red-200 text-red-700 p-4 rounded-lg mb-6"
+          >
+            Error: {error}
+          </div>
+        )}
+
+        {status && (
+          <div
+            role="status"
+            aria-live="polite"
+            className="bg-white shadow rounded-lg p-6"
+          >
+            <h2 className="text-xl font-semibold text-gray-800 mb-4">
+              Application Status
+            </h2>
+            <dl className="space-y-3">
+              <div className="flex justify-between">
+                <dt className="text-gray-600">State:</dt>
+                <dd className="font-medium text-gray-900">{status.state}</dd>
+              </div>
+              <div className="flex justify-between">
+                <dt className="text-gray-600">Source:</dt>
+                <dd className="font-medium text-gray-900">{status.source}</dd>
+              </div>
+              {status.sequenceIndex !== undefined && (
+                <div className="flex justify-between">
+                  <dt className="text-gray-600">Sequence Index:</dt>
+                  <dd className="font-medium text-gray-900">
+                    {status.sequenceIndex}
+                  </dd>
+                </div>
+              )}
+              <div className="flex justify-between border-t pt-3">
+                <dt className="text-gray-600">API Calls Made:</dt>
+                <dd className="font-medium text-gray-900">{callCount}</dd>
+              </div>
+            </dl>
+          </div>
+        )}
+
+        <div className="mt-8 text-sm text-gray-500">
+          <h3 className="font-medium text-gray-700 mb-2">Expected Behavior:</h3>
+          <ul className="list-disc pl-5 space-y-1">
+            <li>
+              <strong>Default scenario:</strong> Returns sequence response with
+              source &quot;default-sequence&quot;
+            </li>
+            <li>
+              <strong>issue335SimpleResponse scenario:</strong> Returns simple
+              response with source &quot;issue335-simple-response&quot; and
+              state &quot;ready&quot;
+            </li>
+          </ul>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/nextjs-pages-router-example/tests/playwright/issue-335-scenario-switching.spec.ts
+++ b/apps/nextjs-pages-router-example/tests/playwright/issue-335-scenario-switching.spec.ts
@@ -1,0 +1,74 @@
+/**
+ * Issue #335: Active scenario simple response overrides default sequence
+ *
+ * When switching to a scenario, that scenario's mocks must take precedence
+ * over default scenario mocks for the same endpoint - regardless of specificity.
+ *
+ * @see https://github.com/citypaul/scenarist/issues/335
+ */
+
+import { test, expect } from "./fixtures";
+
+test.describe("Issue #335: Active scenario simple response overrides default sequence", () => {
+  test("returns active scenario's simple response instead of default's sequence mock", async ({
+    page,
+    switchScenario,
+  }) => {
+    await switchScenario(page, "issue335SimpleResponse");
+    await page.goto("/issue335");
+
+    // Click the check button to trigger the API call
+    await page
+      .getByRole("button", { name: "Check Application Status" })
+      .click();
+
+    // Verify the response shows the active scenario's simple response
+    const statusRegion = page.getByRole("status");
+    await expect(statusRegion).toContainText("ready");
+    await expect(statusRegion).toContainText("issue335-simple-response");
+  });
+
+  test("uses default sequence when no scenario is set", async ({
+    page,
+    switchScenario,
+  }) => {
+    // Switch to default scenario explicitly
+    await switchScenario(page, "default");
+    await page.goto("/issue335");
+
+    // Click the check button to trigger the API call
+    await page
+      .getByRole("button", { name: "Check Application Status" })
+      .click();
+
+    // Verify the response shows the default scenario's sequence response
+    const statusRegion = page.getByRole("status");
+    await expect(statusRegion).toContainText("default-sequence");
+  });
+
+  test("resumes default sequence after switching back from active scenario", async ({
+    page,
+    switchScenario,
+  }) => {
+    // First, switch to the issue335 scenario
+    await switchScenario(page, "issue335SimpleResponse");
+    await page.goto("/issue335");
+
+    // Click to get the active scenario's response
+    await page
+      .getByRole("button", { name: "Check Application Status" })
+      .click();
+    const statusRegion = page.getByRole("status");
+    await expect(statusRegion).toContainText("issue335-simple-response");
+
+    // Switch back to default scenario
+    await switchScenario(page, "default");
+
+    // Navigate again and click to get the default scenario's response
+    await page.goto("/issue335");
+    await page
+      .getByRole("button", { name: "Check Application Status" })
+      .click();
+    await expect(statusRegion).toContainText("default-sequence");
+  });
+});


### PR DESCRIPTION
## Summary

- Fixed mock selection priority so active scenario's fallback mocks take precedence over default scenario mocks
- Added `activeHasFallbackMock` tracking in `getMocksFromScenarios` to detect when active scenario has a mock without match criteria
- When active scenario explicitly covers an endpoint with a fallback mock, default scenario mocks are excluded

## Problem

When switching to a scenario that has a simple response mock (no match criteria) for an endpoint, the default scenario's sequence mock would incorrectly be selected due to specificity ordering.

Example: If default scenario has a sequence mock for `/api/applications/:id` and active scenario has a simple response mock for the same endpoint, the sequence mock was being used instead of the simple response.

## Solution

Track whether the active scenario has a "fallback mock" (one without match criteria) for the URL+method combination. When it does, exclude default scenario mocks for that endpoint, ensuring the active scenario fully overrides default behavior.

## Test plan

- [x] Added unit tests for `getMocksFromScenarios` with the three key scenarios
- [x] Added E2E test in Express example (`issue-335-simple-response-override.test.ts`)
- [x] Added E2E test in Next.js App Router example (`issue-335-scenario-switching.spec.ts`)
- [x] Added E2E test in Next.js Pages Router example (`issue-335-scenario-switching.spec.ts`)
- [x] All 314+ tests pass across all packages
- [x] TypeScript strict mode satisfied

Closes #335

🤖 Generated with [Claude Code](https://claude.com/claude-code)