### PR TITLE
docs: Add Server Actions section to RSC guide

### DIFF
--- a/apps/docs/src/content/docs/frameworks/nextjs-app-router/rsc-guide.mdx
+++ b/apps/docs/src/content/docs/frameworks/nextjs-app-router/rsc-guide.mdx
@@ -1058,6 +1058,353 @@ Scenarist lets you test authentication flows without setting up real auth provid
 
 ---
 
+## Pattern 6: Server Actions
+
+Server Actions are server-side functions that can be called directly from Client Components. They're commonly used for form submissions, mutations, and any operation that requires server-side execution. Testing Server Actions with Scenarist requires the same header forwarding pattern used in Server Components.
+
+### The Server Actions Testing Challenge
+
+Server Actions run on the server and make their own fetch requests. This creates a testing challenge:
+
+1. **Isolated server execution** - Server Actions don't inherit browser headers automatically
+2. **Test ID routing** - Without the `x-scenarist-test-id` header, MSW can't route to the correct scenario
+3. **Concurrent test isolation** - Multiple tests running in parallel need separate mock responses
+
+**Solution:** Forward headers from the incoming request to outgoing fetch calls using `getScenaristHeadersFromReadonlyHeaders()`.
+
+### Example: Contact Form with Server Action
+
+**Server Action:** [`app/actions/actions.ts`](https://github.com/citypaul/scenarist/blob/main/apps/nextjs-app-router-example/app/actions/actions.ts)
+
+```typescript
+// app/actions/actions.ts
+"use server";
+
+import { headers } from "next/headers";
+import { getScenaristHeadersFromReadonlyHeaders } from "@scenarist/nextjs-adapter/app";
+
+type FormState = {
+  readonly success: boolean;
+  readonly message: string;
+} | null;
+
+export async function submitContactForm(
+  _prevState: FormState,
+  formData: FormData
+): Promise<FormState> {
+  const headersList = await headers();
+
+  const response = await fetch("http://localhost:3001/contact", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      // Forward Scenarist headers for test isolation
+      // Each test gets its own scenario based on x-scenarist-test-id
+      ...getScenaristHeadersFromReadonlyHeaders(headersList),
+    },
+    body: JSON.stringify({
+      name: formData.get("name"),
+      email: formData.get("email"),
+      message: formData.get("message"),
+    }),
+  });
+
+  const data: unknown = await response.json();
+
+  if (!response.ok) {
+    const errorMessage =
+      data !== null &&
+      typeof data === "object" &&
+      "error" in data &&
+      typeof data.error === "string"
+        ? data.error
+        : "Submission failed";
+    return { success: false, message: errorMessage };
+  }
+
+  const successMessage =
+    data !== null &&
+    typeof data === "object" &&
+    "message" in data &&
+    typeof data.message === "string"
+      ? data.message
+      : "Message sent!";
+  return { success: true, message: successMessage };
+}
+```
+
+<Aside type="tip" title="Header Forwarding is Critical">
+The `getScenaristHeadersFromReadonlyHeaders(headersList)` call forwards the test ID from the browser request to the external API call. Without this, all concurrent tests would share the same mock responses, causing flaky tests.
+</Aside>
+
+**Page Component:** [`app/actions/page.tsx`](https://github.com/citypaul/scenarist/blob/main/apps/nextjs-app-router-example/app/actions/page.tsx)
+
+```typescript
+// app/actions/page.tsx
+"use client";
+
+import { useActionState } from "react";
+import { submitContactForm } from "./actions";
+
+export default function ActionsPage() {
+  const [state, formAction, isPending] = useActionState(submitContactForm, null);
+
+  return (
+    <main className="min-h-screen p-8">
+      <h1 className="text-4xl font-bold mb-8">Server Actions Demo</h1>
+
+      <form action={formAction} className="max-w-md space-y-4">
+        <div>
+          <label htmlFor="name" className="block mb-1">Name</label>
+          <input id="name" name="name" type="text" required className="w-full border p-2" />
+        </div>
+        <div>
+          <label htmlFor="email" className="block mb-1">Email</label>
+          <input id="email" name="email" type="email" required className="w-full border p-2" />
+        </div>
+        <div>
+          <label htmlFor="message" className="block mb-1">Message</label>
+          <textarea id="message" name="message" required className="w-full border p-2" />
+        </div>
+        <button type="submit" disabled={isPending} className="bg-blue-600 text-white px-4 py-2">
+          {isPending ? "Sending..." : "Send Message"}
+        </button>
+      </form>
+
+      {state?.success && (
+        <div role="status" className="mt-4 p-4 bg-green-100 text-green-800">
+          {state.message}
+        </div>
+      )}
+      {state?.success === false && (
+        <div role="alert" className="mt-4 p-4 bg-red-100 text-red-800">
+          {state.message}
+        </div>
+      )}
+    </main>
+  );
+}
+```
+
+### Scenario Definitions
+
+Server Actions scenarios follow the same pattern as Server Component scenarios. Multiple scenarios let you test success, error, and edge cases:
+
+**Scenarios:** [`lib/scenarios.ts`](https://github.com/citypaul/scenarist/blob/main/apps/nextjs-app-router-example/lib/scenarios.ts)
+
+```typescript
+// lib/scenarios.ts
+import type { ScenaristScenario } from '@scenarist/nextjs-adapter/app';
+
+// Success scenario
+export const contactFormSuccessScenario: ScenaristScenario = {
+  id: 'contactFormSuccess',
+  name: 'Contact Form - Success',
+  description: 'Contact form submission succeeds',
+  mocks: [
+    {
+      method: 'POST',
+      url: 'http://localhost:3001/contact',
+      response: {
+        status: 200,
+        body: { success: true, message: 'Message sent successfully!' },
+      },
+    },
+  ],
+};
+
+// Error scenario - server failure
+export const contactFormErrorScenario: ScenaristScenario = {
+  id: 'contactFormError',
+  name: 'Contact Form - Error',
+  description: 'Contact form submission fails with server error',
+  mocks: [
+    {
+      method: 'POST',
+      url: 'http://localhost:3001/contact',
+      response: {
+        status: 500,
+        body: { error: 'Server error. Please try again later.' },
+      },
+    },
+  ],
+};
+
+// Edge case - duplicate email
+export const contactFormDuplicateScenario: ScenaristScenario = {
+  id: 'contactFormDuplicate',
+  name: 'Contact Form - Duplicate Email',
+  description: 'Contact form fails due to existing email',
+  mocks: [
+    {
+      method: 'POST',
+      url: 'http://localhost:3001/contact',
+      response: {
+        status: 409,
+        body: { error: 'Email already registered in our system.' },
+      },
+    },
+  ],
+};
+
+// Request matching - VIP email domains
+export const contactFormVipScenario: ScenaristScenario = {
+  id: 'contactFormVip',
+  name: 'Contact Form - VIP Domain',
+  description: 'VIP email domains get priority response',
+  mocks: [
+    {
+      method: 'POST',
+      url: 'http://localhost:3001/contact',
+      match: {
+        body: { email: { contains: '@vip.' } },  // Match on request body
+      },
+      response: {
+        status: 200,
+        body: { success: true, message: 'Priority response - VIP request received!' },
+      },
+    },
+  ],
+};
+```
+
+<Aside type="note" title="Request Body Matching">
+The VIP scenario demonstrates request body matching with `{ contains: '@vip.' }`. This routes requests based on the email domain in the form data, enabling conditional responses without separate scenarios for each email.
+</Aside>
+
+### Test Implementation
+
+**Test:** [`tests/playwright/server-actions.spec.ts`](https://github.com/citypaul/scenarist/blob/main/apps/nextjs-app-router-example/tests/playwright/server-actions.spec.ts)
+
+```typescript
+// tests/playwright/server-actions.spec.ts
+import { test, expect } from './fixtures';
+
+test.describe('Server Actions - Contact Form', () => {
+  test('should submit contact form successfully', async ({
+    page,
+    switchScenario,
+  }) => {
+    await switchScenario(page, 'contactFormSuccess');
+    await page.goto('/actions');
+
+    await page.getByLabel('Name').fill('John Doe');
+    await page.getByLabel('Email').fill('john@example.com');
+    await page.getByLabel('Message').fill('Hello!');
+
+    await page.getByRole('button', { name: 'Send Message' }).click();
+
+    await expect(page.getByRole('status')).toContainText(
+      'Message sent successfully'
+    );
+  });
+
+  test('should show error when server fails', async ({
+    page,
+    switchScenario,
+  }) => {
+    await switchScenario(page, 'contactFormError');
+    await page.goto('/actions');
+
+    await page.getByLabel('Name').fill('John Doe');
+    await page.getByLabel('Email').fill('john@example.com');
+    await page.getByLabel('Message').fill('Hello!');
+
+    await page.getByRole('button', { name: 'Send Message' }).click();
+
+    await expect(page.getByText('Server error')).toBeVisible();
+  });
+
+  test('should show duplicate email message', async ({
+    page,
+    switchScenario,
+  }) => {
+    await switchScenario(page, 'contactFormDuplicate');
+    await page.goto('/actions');
+
+    await page.getByLabel('Name').fill('John Doe');
+    await page.getByLabel('Email').fill('existing@example.com');
+    await page.getByLabel('Message').fill('Hello!');
+
+    await page.getByRole('button', { name: 'Send Message' }).click();
+
+    await expect(page.getByText('Email already registered')).toBeVisible();
+  });
+
+  test('should show VIP acknowledgment for VIP email domains', async ({
+    page,
+    switchScenario,
+  }) => {
+    await switchScenario(page, 'contactFormVip');
+    await page.goto('/actions');
+
+    await page.getByLabel('Name').fill('VIP User');
+    await page.getByLabel('Email').fill('user@vip.example.com');
+    await page.getByLabel('Message').fill('Priority request');
+
+    await page.getByRole('button', { name: 'Send Message' }).click();
+
+    await expect(page.getByRole('status')).toContainText('Priority response');
+  });
+});
+```
+
+### Key Points for Server Actions Tests
+
+| Aspect | Consideration |
+|--------|---------------|
+| **Header forwarding** | Server Actions MUST forward `x-scenarist-test-id` via `getScenaristHeadersFromReadonlyHeaders()` |
+| **`useActionState` hook** | React 19's `useActionState` provides `[state, formAction, isPending]` for form state management |
+| **Request body matching** | Use `match.body` to route requests based on form data (e.g., VIP email domains) |
+| **ARIA roles** | Use `role="status"` for success and `role="alert"` for errors for reliable test selection |
+| **Error handling** | Test both HTTP errors (500) and business logic errors (409 duplicate) |
+
+### Common Server Actions Testing Patterns
+
+**Testing form validation:**
+
+```typescript
+test('should show validation error for invalid email', async ({
+  page,
+  switchScenario,
+}) => {
+  await switchScenario(page, 'contactFormValidation');
+  await page.goto('/actions');
+
+  await page.getByLabel('Email').fill('invalid-email');  // Missing @
+  await page.getByRole('button', { name: 'Send Message' }).click();
+
+  await expect(page.getByText('Invalid email format')).toBeVisible();
+});
+```
+
+**Testing loading states:**
+
+```typescript
+test('should show loading state while submitting', async ({
+  page,
+  switchScenario,
+}) => {
+  await switchScenario(page, 'contactFormSuccess');
+  await page.goto('/actions');
+
+  await page.getByLabel('Name').fill('John Doe');
+  await page.getByLabel('Email').fill('john@example.com');
+  await page.getByLabel('Message').fill('Hello!');
+
+  // Click and immediately check for loading state
+  await page.getByRole('button', { name: 'Send Message' }).click();
+
+  // Button should show loading text
+  await expect(page.getByRole('button')).toContainText('Sending...');
+
+  // Eventually shows success
+  await expect(page.getByRole('status')).toBeVisible();
+});
+```
+
+---
+
 ## Common Pitfalls and Debugging
 
 ### Pitfall 1: Missing Header Forwarding
@@ -1149,27 +1496,12 @@ await fetch(`http://localhost:3001/github/jobs/${jobId}`, {  // ✅ Matches patt
 
 The following advanced RSC patterns will be covered in upcoming documentation:
 
-### Server Actions
-
-Testing form submissions and mutations with Server Actions:
-
-```typescript
-// Future pattern preview
-test('submits form via Server Action', async ({ page, switchScenario }) => {
-  await switchScenario(page, 'formSubmission');
-  await page.goto('/checkout');
-  await page.fill('[name="email"]', 'test@example.com');
-  await page.click('button[type="submit"]');
-  await expect(page.getByText('Order confirmed')).toBeVisible();
-});
-```
-
 ### Error Boundaries
 
 Testing error handling in Server Components with error boundaries.
 
 <Aside type="note" title="Example Implementations">
-These patterns require example implementations that are being developed. Once available, this guide will be updated with complete working examples and tests.
+This pattern requires example implementations that are being developed. Once available, this guide will be updated with complete working examples and tests.
 </Aside>
 
 ---


### PR DESCRIPTION
## Summary

Closes #212

- Add Pattern 6: Server Actions to the RSC guide
- Document the Server Actions testing challenge (header forwarding requirement)
- Include contact form example with Server Action (`actions.ts`)
- Include Client Component with `useActionState` hook (`page.tsx`)
- Add four scenario definitions (success, error, duplicate email, VIP domain matching)
- Include complete test implementation (`server-actions.spec.ts`)
- Add key points table and common testing patterns (validation, loading states)
- Update "Coming Soon" section to remove Server Actions

## Test plan

- [ ] Verify docs build successfully with `pnpm --filter=@scenarist/docs typecheck`
- [ ] Review documentation content for accuracy and completeness
- [ ] Verify links to example files are correct

🤖 Generated with [Claude Code](https://claude.com/claude-code)