### PR TITLE
chore: test attestation action v3.0.0

### DIFF
--- a/.changeset/test-attestation-v3.md
+++ b/.changeset/test-attestation-v3.md
@@ -1,0 +1,5 @@
+---
+"@scenarist/core": patch
+---
+
+chore: fix attest-build-provenance version comment (v1.4.4 → v3.0.0)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -129,7 +129,7 @@ jobs:
 
       - name: Attest build provenance
         if: steps.changesets.outputs.published == 'true'
-        uses: actions/attest-build-provenance@977bb373ede98d70efdf65b84cb5f73e068dcc2a # v2.4.0
+        uses: actions/attest-build-provenance@977bb373ede98d70efdf65b84cb5f73e068dcc2a # v3.0.0
         with:
           subject-path: 'attestation-artifacts/*.tgz'
 


### PR DESCRIPTION
## Summary
- Fix version comment for attest-build-provenance (v2.4.0 → v3.0.0)
- Add changeset to trigger a patch release to verify the attestation action works correctly with v3.0.0

## Test plan
- [ ] CI passes
- [ ] Merge to main triggers release workflow
- [ ] Attestation step completes successfully (requires runner v2.327.1+)

🤖 Generated with [Claude Code](https://claude.com/claude-code)