### PR TITLE
fix(ci): add RELEASE_PAT validation with helpful error message

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,6 +32,29 @@ jobs:
         with:
           fetch-depth: 0
 
+      # Fail fast if RELEASE_PAT is not configured
+      # The PAT must have 'repo' and 'workflows' scopes to push changeset-release branches
+      # that contain workflow files. The default GITHUB_TOKEN cannot modify workflow files.
+      - name: Verify RELEASE_PAT is configured
+        env:
+          RELEASE_PAT: ${{ secrets.RELEASE_PAT }}
+        run: |
+          if [ -z "$RELEASE_PAT" ]; then
+            echo "::error::RELEASE_PAT secret is not configured!"
+            echo ""
+            echo "The release workflow requires a Personal Access Token (PAT) with:"
+            echo "  - 'repo' scope (for pushing branches and creating PRs)"
+            echo "  - 'workflows' scope (for pushing changes to .github/workflows/)"
+            echo ""
+            echo "To fix:"
+            echo "  1. Create a PAT at https://github.com/settings/tokens"
+            echo "  2. Select 'repo' and 'workflows' scopes"
+            echo "  3. Add it as a repository secret named 'RELEASE_PAT'"
+            echo "     at https://github.com/${{ github.repository }}/settings/secrets/actions"
+            exit 1
+          fi
+          echo "✅ RELEASE_PAT is configured"
+
       - name: Setup pnpm
         uses: pnpm/action-setup@9fd676a19091d4595eefd76e4bd31c97133911f1 # v4.2.0
 


### PR DESCRIPTION
## Summary

The release workflow was failing at https://github.com/citypaul/scenarist/actions/runs/20043772641 with:

```
! [remote rejected] HEAD -> changeset-release/main (refusing to allow a GitHub App to create or update workflow `.github/workflows/release.yml` without `workflows` permission)
```

**Root cause:** The `RELEASE_PAT` secret is not configured (or is empty), so the changesets action falls back to the default `GITHUB_TOKEN`. The default token cannot push changes to workflow files even with `contents: write` permission - this requires a PAT with `workflows` scope.

**This PR adds:**
- A validation step that fails fast with a clear error message
- Instructions on how to create and configure the required PAT

## To fully fix the release workflow

The repository owner needs to:
1. Create a Personal Access Token at https://github.com/settings/tokens
2. Select `repo` and `workflows` scopes
3. Add it as a repository secret named `RELEASE_PAT` at https://github.com/citypaul/scenarist/settings/secrets/actions

## Test plan

- [ ] PR CI passes
- [ ] After merging, release workflow will show helpful error until PAT is configured
- [ ] After PAT is configured, release workflow should succeed

🤖 Generated with [Claude Code](https://claude.com/claude-code)