### PR TITLE
docs: add Playwright debugging helpers to RSC troubleshooting

### DIFF
--- a/apps/docs/src/content/docs/frameworks/nextjs-app-router/rsc/troubleshooting.mdx
+++ b/apps/docs/src/content/docs/frameworks/nextjs-app-router/rsc/troubleshooting.mdx
@@ -205,6 +205,7 @@ export default async function MyPage() {
 The `@scenarist/playwright-helpers` package provides fixtures to inspect test state directly from your Playwright tests:
 
 ```typescript
+// Import from your configured fixtures file
 import { test, expect } from './fixtures';
 
 test('checkout flow updates cart state', async ({ page, switchScenario, debugState }) => {


### PR DESCRIPTION
## Summary

- Add section 6 to RSC troubleshooting guide showing `debugState` and `waitForDebugState` fixtures
- These Playwright fixtures help debug state-aware mocking flows (carts, polling, etc.)
- Update the Aside to reference both logging docs and Playwright integration guide

## Test plan

- [ ] Preview docs site renders correctly
- [ ] Code examples are syntactically correct
- [ ] Links to Playwright integration guide work

🤖 Generated with [Claude Code](https://claude.com/claude-code)