### PR TITLE
fix(security): use POST for sensitive API key data (CWE-598)

### DIFF
--- a/apps/express-example/src/routes/string-matching.ts
+++ b/apps/express-example/src/routes/string-matching.ts
@@ -48,6 +48,14 @@ const getQueryString = (value: unknown): string | undefined => {
   return typeof value === "string" ? value : undefined;
 };
 
+const getBodyString = (
+  body: Record<string, unknown>,
+  key: string,
+): string | undefined => {
+  const value = body[key];
+  return typeof value === "string" ? value : undefined;
+};
+
 // Security: Encode path parameters to prevent path traversal
 // @see https://github.com/citypaul/scenarist/security/code-scanning/77
 export const setupStringMatchingRoutes = (router: Router): void => {
@@ -67,19 +75,16 @@ export const setupStringMatchingRoutes = (router: Router): void => {
     },
   );
 
-  // NOTE: This endpoint intentionally uses a query parameter for API key to demonstrate
-  // Scenarist's header-based content matching capabilities. In production, use headers
-  // for sensitive data. This is a test endpoint, not a security pattern.
-  // @see https://github.com/citypaul/scenarist/security/code-scanning/74
-  // @see https://github.com/citypaul/scenarist/security/code-scanning/168
-  router.get(
+  // Security fix: Use POST with request body for sensitive data (API key)
+  // @see https://github.com/citypaul/scenarist/issues/386
+  router.post(
     "/api/test-string-match/starts-with",
     async (req: Request, res: Response) => {
       return handleProxyRequest(
         () => ({
           url: "https://api.stripe.com/v1/api-keys",
           headers: buildHeaders({
-            "x-api-key": getQueryString(req.query.apiKey),
+            "x-api-key": getBodyString(req.body, "apiKey"),
           }),
         }),
         req,

--- a/apps/express-example/tests/string-matching.test.ts
+++ b/apps/express-example/tests/string-matching.test.ts
@@ -100,10 +100,10 @@ describe("String Matching Strategies - Express", () => {
       .set(SCENARIST_TEST_ID_HEADER, "string-test-3")
       .send({ scenario: scenarios.stringMatching.id });
 
-    // Make request with API key starting with 'sk_'
+    // Make request with API key starting with 'sk_' (POST body for sensitive data)
     const response = await request(fixtures.app)
-      .get("/api/test-string-match/starts-with")
-      .query({ apiKey: "sk_test_12345" })
+      .post("/api/test-string-match/starts-with")
+      .send({ apiKey: "sk_test_12345" })
       .set(SCENARIST_TEST_ID_HEADER, "string-test-3");
 
     // Verify valid API key response
@@ -119,10 +119,10 @@ describe("String Matching Strategies - Express", () => {
       .set(SCENARIST_TEST_ID_HEADER, "string-test-4")
       .send({ scenario: scenarios.stringMatching.id });
 
-    // Make request with API key NOT starting with 'sk_'
+    // Make request with API key NOT starting with 'sk_' (POST body for sensitive data)
     const response = await request(fixtures.app)
-      .get("/api/test-string-match/starts-with")
-      .query({ apiKey: "pk_test_12345" })
+      .post("/api/test-string-match/starts-with")
+      .send({ apiKey: "pk_test_12345" })
       .set(SCENARIST_TEST_ID_HEADER, "string-test-4");
 
     // Should not match the startsWith pattern, falls back to catch-all handler


### PR DESCRIPTION
## Summary

- Convert `/api/test-string-match/starts-with` endpoint from GET to POST to prevent sensitive data (API key) from being transmitted in query parameters
- Add `getBodyString` helper function to safely extract values from request body
- Update tests to use POST with request body instead of GET with query params

## Security Issue

**Alert:** https://github.com/citypaul/scenarist/security/code-scanning/168
**CWE:** [CWE-598: Use of GET Request Method with Sensitive Query Strings](https://cwe.mitre.org/data/definitions/598.html)
**Severity:** Medium

Sensitive information in URLs may be:
- Logged in browser history, web servers, and proxies
- Displayed on-screen or bookmarked
- Disclosed via the Referer header

Fixes #386

## Test plan

- [x] All 105 express-example tests pass
- [x] TypeScript strict mode compiles without errors
- [ ] CI pipeline passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)