### PR TITLE
fix(security): correct nosemgrep rule ID for prototype pollution false positive

### DIFF
--- a/internal/core/src/domain/template-replacement.ts
+++ b/internal/core/src/domain/template-replacement.ts
@@ -139,13 +139,16 @@ const resolveTemplatePath = (
     }
 
     // Security: Prevent prototype pollution attacks
+    // This is a READ-only traversal, not a write operation, so prototype pollution is not possible.
+    // Additionally, we explicitly block dangerous keys (__proto__, constructor, prototype) via isDangerousKey()
+    // and verify the property exists on the object itself (not prototype) via Object.hasOwn().
     // @see https://github.com/citypaul/scenarist/security/code-scanning/165
     if (isDangerousKey(segment) || !Object.hasOwn(current, segment)) {
       return undefined;
     }
 
-    // nosemgrep: javascript.lang.security.audit.prototype-pollution.prototype-pollution-loop
-    // eslint-disable-next-line security/detect-object-injection -- Segment validated by isDangerousKey and Object.hasOwn checks above
+    // nosemgrep: javascript.lang.security.audit.prototype-pollution.prototype-pollution-loop.prototype-pollution-loop
+    // eslint-disable-next-line security/detect-object-injection -- Read-only traversal with isDangerousKey and Object.hasOwn guards
     current = current[segment];
 
     // Guard: Return undefined if property doesn't exist


### PR DESCRIPTION
## Summary

- Fixes Semgrep alert #165 (false positive for prototype pollution)
- Corrects the `nosemgrep` comment to use the full rule ID
- Adds documentation explaining why this is a false positive

## Analysis

The alert flags line 149 (`current = current[segment]`) as potential prototype pollution. This is a **false positive** because:

1. **Read-only operation**: This code traverses an object to read values, it does not write/modify anything
2. **isDangerousKey() guard**: Explicitly blocks `__proto__`, `constructor`, `prototype` keys
3. **Object.hasOwn() guard**: Ensures the property exists on the object itself, not its prototype

## Changes

- Fixed `nosemgrep` comment to use full rule ID: `javascript.lang.security.audit.prototype-pollution.prototype-pollution-loop.prototype-pollution-loop`
- Added inline documentation explaining the security review

## Test plan

- [x] All 554 core tests passing
- [x] TypeScript typecheck passes

Fixes #390

🤖 Generated with [Claude Code](https://claude.com/claude-code)