### PR TITLE
fix(ci): pin npm package with integrity verification

### DIFF
--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -83,11 +83,19 @@ jobs:
           git diff --staged --quiet || git commit -m "chore: version packages for ${{ steps.tag.outputs.tag }}"
           git push
 
-      # Pin npm version for supply chain security
+      # Pin npm version with integrity verification for supply chain security
       # @see https://github.com/citypaul/scenarist/security/code-scanning/56
+      # @see https://github.com/citypaul/scenarist/issues/392
       - name: Upgrade npm for OIDC trusted publishing
+        env:
+          NPM_VERSION: '11.6.4'
+          NPM_SHA512: '1118cab46a05a50aee6bff5b1b4fa1df18afff89d57465620a3518035026955db87c5bdf9d207b07b7487d99f2490d450cb774655ad63ec2cba7bf1d0ad25d45'
         run: |
-          npm install -g npm@11.6.4
+          # Download npm tarball and verify integrity before installing
+          curl -fsSL "https://registry.npmjs.org/npm/-/npm-${NPM_VERSION}.tgz" -o npm.tgz
+          echo "${NPM_SHA512}  npm.tgz" | sha512sum -c -
+          npm install -g ./npm.tgz
+          rm npm.tgz
           echo "npm version: $(npm --version)"
 
       - name: Publish to npm

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,11 +51,19 @@ jobs:
       - name: Build packages
         run: pnpm build
 
-      # Pin npm version for supply chain security
+      # Pin npm version with integrity verification for supply chain security
       # @see https://github.com/citypaul/scenarist/security/code-scanning/57
+      # @see https://github.com/citypaul/scenarist/issues/392
       - name: Upgrade npm for OIDC trusted publishing
+        env:
+          NPM_VERSION: '11.6.4'
+          NPM_SHA512: '1118cab46a05a50aee6bff5b1b4fa1df18afff89d57465620a3518035026955db87c5bdf9d207b07b7487d99f2490d450cb774655ad63ec2cba7bf1d0ad25d45'
         run: |
-          npm install -g npm@11.6.4
+          # Download npm tarball and verify integrity before installing
+          curl -fsSL "https://registry.npmjs.org/npm/-/npm-${NPM_VERSION}.tgz" -o npm.tgz
+          echo "${NPM_SHA512}  npm.tgz" | sha512sum -c -
+          npm install -g ./npm.tgz
+          rm npm.tgz
           echo "npm version: $(npm --version)"
 
       - name: Create Release Pull Request or Publish


### PR DESCRIPTION
## Summary

- Add SHA512 integrity verification for npm@11.6.4 in release workflows
- Fix OpenSSF Scorecard "Pinned-Dependencies" alerts #148 and #149

## Details

The OpenSSF Scorecard was flagging `npm install -g npm@11.6.4` as an unpinned dependency because npm packages weren't verified by hash.

**Solution:**
1. Download the npm tarball directly from registry.npmjs.org
2. Verify SHA512 hash before installation
3. Install from the verified local tarball

```yaml
env:
  NPM_VERSION: '11.6.4'
  NPM_SHA512: '1118cab46a05a50aee6bff5b1b4fa1df18afff89d57465620a3518035026955db87c5bdf9d207b07b7487d99f2490d450cb774655ad63ec2cba7bf1d0ad25d45'
run: |
  curl -fsSL "https://registry.npmjs.org/npm/-/npm-${NPM_VERSION}.tgz" -o npm.tgz
  echo "${NPM_SHA512}  npm.tgz" | sha512sum -c -
  npm install -g ./npm.tgz
```

## Files Changed

- `.github/workflows/release.yml` - Add integrity verification
- `.github/workflows/pre-release.yml` - Add integrity verification

## Test plan

- [x] Verified SHA512 hash matches npm registry
- [x] Tested integrity check locally
- [ ] CI workflow passes

## Related

- Code Scanning Alert #148: https://github.com/citypaul/scenarist/security/code-scanning/148
- Code Scanning Alert #149: https://github.com/citypaul/scenarist/security/code-scanning/149

Closes #392

🤖 Generated with [Claude Code](https://claude.com/claude-code)