### PR TITLE
fix(docs): prevent light mode dark flash

### DIFF
--- a/apps/docs/astro.config.mjs
+++ b/apps/docs/astro.config.mjs
@@ -8,6 +8,38 @@ import icon from "astro-icon";
 
 import cloudflare from "@astrojs/cloudflare";
 
+const starlightThemeBootstrapScript = `(() => {
+  const getPreferredColorScheme = () =>
+    window.matchMedia('(prefers-color-scheme: light)').matches ? 'light' : 'dark';
+
+  try {
+    const stored = localStorage.getItem('starlight-theme');
+    const theme =
+      stored === 'dark' || stored === 'light' ? stored : getPreferredColorScheme();
+    document.documentElement.dataset.theme = theme;
+  } catch {
+    document.documentElement.dataset.theme = getPreferredColorScheme();
+  }
+})();`;
+
+const themeCriticalStyle = `
+html {
+  background: #ffffff;
+  color-scheme: light;
+}
+
+html.dark,
+html[data-theme='dark'] {
+  background: #030304;
+  color-scheme: dark;
+}
+
+html[data-theme='light'] {
+  background: #ffffff;
+  color-scheme: light;
+}
+`;
+
 // https://astro.build/config
 export default defineConfig({
   site: "https://scenarist.io",
@@ -30,6 +62,16 @@ export default defineConfig({
       title: "Scenarist",
       description: "Playwright tests that hit your real server. Server Components, routes, and middleware execute for real. Mock only external APIs—switchable per test.",
       head: [
+        {
+          tag: "script",
+          attrs: { "data-starlight-theme-bootstrap": "" },
+          content: starlightThemeBootstrapScript,
+        },
+        {
+          tag: "style",
+          attrs: { "data-theme-critical": "" },
+          content: themeCriticalStyle,
+        },
         // Open Graph
         {
           tag: "meta",

--- a/apps/docs/astro.config.mjs
+++ b/apps/docs/astro.config.mjs
@@ -8,38 +8,6 @@ import icon from "astro-icon";
 
 import cloudflare from "@astrojs/cloudflare";
 
-const starlightThemeBootstrapScript = `(() => {
-  const getPreferredColorScheme = () =>
-    window.matchMedia('(prefers-color-scheme: light)').matches ? 'light' : 'dark';
-
-  try {
-    const stored = localStorage.getItem('starlight-theme');
-    const theme =
-      stored === 'dark' || stored === 'light' ? stored : getPreferredColorScheme();
-    document.documentElement.dataset.theme = theme;
-  } catch {
-    document.documentElement.dataset.theme = getPreferredColorScheme();
-  }
-})();`;
-
-const themeCriticalStyle = `
-html {
-  background: #ffffff;
-  color-scheme: light;
-}
-
-html.dark,
-html[data-theme='dark'] {
-  background: #030304;
-  color-scheme: dark;
-}
-
-html[data-theme='light'] {
-  background: #ffffff;
-  color-scheme: light;
-}
-`;
-
 // https://astro.build/config
 export default defineConfig({
   site: "https://scenarist.io",
@@ -62,16 +30,6 @@ export default defineConfig({
       title: "Scenarist",
       description: "Playwright tests that hit your real server. Server Components, routes, and middleware execute for real. Mock only external APIs—switchable per test.",
       head: [
-        {
-          tag: "script",
-          attrs: { "data-starlight-theme-bootstrap": "" },
-          content: starlightThemeBootstrapScript,
-        },
-        {
-          tag: "style",
-          attrs: { "data-theme-critical": "" },
-          content: themeCriticalStyle,
-        },
         // Open Graph
         {
           tag: "meta",

--- a/apps/docs/src/components/landing/Hero.astro
+++ b/apps/docs/src/components/landing/Hero.astro
@@ -15,7 +15,7 @@ const releasesUrl = 'https://github.com/citypaul/scenarist/releases';
 
   <div class="max-w-4xl mx-auto text-center relative z-10">
     <!-- Version Badge -->
-    <a href={releasesUrl} class="inline-flex items-center gap-2 px-3 py-1 rounded-full border border-gray-200 dark:border-white/10 bg-white/50 dark:bg-white/5 backdrop-blur-sm text-xs font-mono text-primary mb-8 hover:border-primary/50 transition-colors">
+    <a href={releasesUrl} class="inline-flex items-center gap-2 px-3 py-1 rounded-full border border-gray-200 dark:border-white/10 bg-white/80 dark:bg-white/5 backdrop-blur-sm text-xs font-mono text-violet-700 dark:text-primary mb-8 hover:border-primary/50 transition-colors">
       <span class="flex w-2 h-2 rounded-full bg-primary animate-pulse"></span>
       v{version} Available
     </a>

--- a/apps/docs/src/layouts/LandingLayout.astro
+++ b/apps/docs/src/layouts/LandingLayout.astro
@@ -21,7 +21,7 @@ const siteName = 'Scenarist';
 ---
 
 <!DOCTYPE html>
-<html lang="en" class="dark">
+<html lang="en">
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
@@ -58,6 +58,42 @@ const siteName = 'Scenarist';
 
   <!-- Theme Color -->
   <meta name="theme-color" content="#8B5CF6" />
+
+  <script is:inline data-theme-bootstrap>
+    (() => {
+      const getPreferredColorScheme = () =>
+        window.matchMedia('(prefers-color-scheme: light)').matches ? 'light' : 'dark';
+
+      try {
+        const stored = localStorage.getItem('starlight-theme');
+        const theme =
+          stored === 'dark' || stored === 'light' ? stored : getPreferredColorScheme();
+        document.documentElement.classList.toggle('dark', theme === 'dark');
+        document.documentElement.dataset.theme = theme;
+      } catch {
+        const theme = getPreferredColorScheme();
+        document.documentElement.classList.toggle('dark', theme === 'dark');
+        document.documentElement.dataset.theme = theme;
+      }
+    })();
+  </script>
+  <style is:inline data-theme-critical>
+    html {
+      background: #ffffff;
+      color-scheme: light;
+    }
+
+    html.dark,
+    html[data-theme='dark'] {
+      background: #030304;
+      color-scheme: dark;
+    }
+
+    html[data-theme='light'] {
+      background: #ffffff;
+      color-scheme: light;
+    }
+  </style>
 
   <!-- Plausible Analytics (proxied through Cloudflare) -->
   <script defer data-domain="scenarist.io" data-api="/api/event" src="/js/script.js"></script>

--- a/apps/docs/src/layouts/LandingLayout.astro
+++ b/apps/docs/src/layouts/LandingLayout.astro
@@ -63,37 +63,20 @@ const siteName = 'Scenarist';
     (() => {
       const getPreferredColorScheme = () =>
         window.matchMedia('(prefers-color-scheme: light)').matches ? 'light' : 'dark';
+      const applyTheme = (theme) => {
+        const normalizedTheme = theme === 'light' ? 'light' : 'dark';
+        document.documentElement.dataset.theme = normalizedTheme;
+        document.documentElement.classList.toggle('dark', normalizedTheme === 'dark');
+      };
 
       try {
         const stored = localStorage.getItem('starlight-theme');
-        const theme =
-          stored === 'dark' || stored === 'light' ? stored : getPreferredColorScheme();
-        document.documentElement.classList.toggle('dark', theme === 'dark');
-        document.documentElement.dataset.theme = theme;
+        applyTheme(stored || getPreferredColorScheme());
       } catch {
-        const theme = getPreferredColorScheme();
-        document.documentElement.classList.toggle('dark', theme === 'dark');
-        document.documentElement.dataset.theme = theme;
+        applyTheme(getPreferredColorScheme());
       }
     })();
   </script>
-  <style is:inline data-theme-critical>
-    html {
-      background: #ffffff;
-      color-scheme: light;
-    }
-
-    html.dark,
-    html[data-theme='dark'] {
-      background: #030304;
-      color-scheme: dark;
-    }
-
-    html[data-theme='light'] {
-      background: #ffffff;
-      color-scheme: light;
-    }
-  </style>
 
   <!-- Plausible Analytics (proxied through Cloudflare) -->
   <script defer data-domain="scenarist.io" data-api="/api/event" src="/js/script.js"></script>
@@ -119,12 +102,12 @@ const siteName = 'Scenarist';
         if (isValidTheme(stored)) {
           return stored;
         }
-        // Empty string or null means 'auto' in Starlight - use system preference
         if (stored === '' || stored === null) {
           return getPreferredColorScheme();
         }
+        return 'dark';
       }
-      return 'dark';
+      return getPreferredColorScheme();
     };
 
     const updateAriaPressed = (isDark: boolean): void => {
@@ -136,12 +119,8 @@ const siteName = 'Scenarist';
 
     const setTheme = (theme: Theme): void => {
       const isDark = theme === 'dark';
-      if (isDark) {
-        document.documentElement.classList.add('dark');
-      } else {
-        document.documentElement.classList.remove('dark');
-      }
-      // Store in Starlight's format for cross-page sync
+      document.documentElement.dataset.theme = theme;
+      document.documentElement.classList.toggle('dark', isDark);
       localStorage.setItem(STORAGE_KEY, theme);
       updateAriaPressed(isDark);
     };

--- a/apps/docs/src/styles/global.css
+++ b/apps/docs/src/styles/global.css
@@ -1,7 +1,6 @@
 @import "tailwindcss";
 
-/* Enable class-based dark mode for Tailwind v4 */
-@custom-variant dark (&:where(.dark, .dark *));
+@custom-variant dark (&:where(.dark, .dark *, [data-theme='dark'], [data-theme='dark'] *));
 
 /* Tailwind v4 Theme Configuration */
 @theme {

--- a/apps/docs/tests/playwright/theme-switching.spec.ts
+++ b/apps/docs/tests/playwright/theme-switching.spec.ts
@@ -27,8 +27,8 @@ type ThemeBootstrapProbeInit = {
   readonly systemTheme: Theme;
 };
 
-const findFirstRenderBlockingStyleIndex = (html: string): number =>
-  html.search(/<link[^>]+rel="stylesheet"|<style\b/);
+const findFirstStylesheetIndex = (html: string): number =>
+  html.search(/<link[^>]+rel="stylesheet"/);
 
 const installThemeBootstrapProbe = async ({
   page,
@@ -102,37 +102,35 @@ test.describe("Theme Switching", () => {
     const themeBootstrapIndex = html.indexOf("data-theme-bootstrap");
     const criticalStyleIndex = html.indexOf("data-theme-critical");
     const bodyIndex = html.indexOf("<body");
-    const firstStyleIndex = findFirstRenderBlockingStyleIndex(html);
 
     expect(html).not.toMatch(/<html[^>]*class="[^"]*\bdark\b[^"]*"/);
+    expect(criticalStyleIndex).toBe(-1);
     expect(themeBootstrapIndex).toBeGreaterThan(-1);
-    expect(criticalStyleIndex).toBeGreaterThan(themeBootstrapIndex);
-    expect(html.slice(firstStyleIndex, firstStyleIndex + 120)).toContain(
-      "data-theme-critical",
-    );
-    expect(firstStyleIndex).toBeGreaterThan(themeBootstrapIndex);
     expect(bodyIndex).toBeGreaterThan(themeBootstrapIndex);
   });
 
-  test("docs pages bootstrap theme before render-blocking styles", async ({
+  test("docs pages use Starlight's built-in theme provider before styles load", async ({
     request,
   }) => {
     const response = await request.get("/getting-started/quick-start/");
     expect(response.ok()).toBe(true);
 
     const html = await response.text();
-    const themeBootstrapIndex = html.indexOf("data-starlight-theme-bootstrap");
-    const criticalStyleIndex = html.indexOf("data-theme-critical");
-    const bodyIndex = html.indexOf("<body");
-    const firstStyleIndex = findFirstRenderBlockingStyleIndex(html);
-
-    expect(themeBootstrapIndex).toBeGreaterThan(-1);
-    expect(criticalStyleIndex).toBeGreaterThan(themeBootstrapIndex);
-    expect(html.slice(firstStyleIndex, firstStyleIndex + 120)).toContain(
-      "data-theme-critical",
+    const customThemeBootstrapIndex = html.indexOf(
+      "data-starlight-theme-bootstrap",
     );
-    expect(firstStyleIndex).toBeGreaterThan(themeBootstrapIndex);
-    expect(bodyIndex).toBeGreaterThan(themeBootstrapIndex);
+    const criticalStyleIndex = html.indexOf("data-theme-critical");
+    const starlightThemeProviderIndex = html.indexOf(
+      "window.StarlightThemeProvider",
+    );
+    const bodyIndex = html.indexOf("<body");
+    const firstStylesheetIndex = findFirstStylesheetIndex(html);
+
+    expect(customThemeBootstrapIndex).toBe(-1);
+    expect(criticalStyleIndex).toBe(-1);
+    expect(starlightThemeProviderIndex).toBeGreaterThan(-1);
+    expect(firstStylesheetIndex).toBeGreaterThan(starlightThemeProviderIndex);
+    expect(bodyIndex).toBeGreaterThan(starlightThemeProviderIndex);
   });
 
   test("landing page applies stored dark theme before body renders", async ({
@@ -227,6 +225,21 @@ test.describe("Theme Switching", () => {
     await expect(page.locator("html")).not.toHaveClass(/dark/);
   });
 
+  test("landing page dark styles follow Starlight data-theme without a class", async ({
+    page,
+  }) => {
+    await page.goto("/");
+    await page.evaluate(() => {
+      document.documentElement.classList.remove("dark");
+      document.documentElement.dataset.theme = "dark";
+    });
+
+    await expect(page.locator("body")).toHaveCSS(
+      "background-color",
+      "rgb(3, 3, 4)",
+    );
+  });
+
   test("theme toggle switches between dark and light", async ({ page }) => {
     // Set dark theme explicitly before navigation
     await page.addInitScript(() => {
@@ -237,6 +250,7 @@ test.describe("Theme Switching", () => {
 
     // Should start in dark mode
     await expect(page.locator("html")).toHaveClass(/dark/);
+    await expect(page.locator("html")).toHaveAttribute("data-theme", "dark");
 
     // Click theme toggle
     const themeToggle = page.getByLabel(/Toggle dark mode/i);
@@ -244,10 +258,12 @@ test.describe("Theme Switching", () => {
 
     // Should now be light mode
     await expect(page.locator("html")).not.toHaveClass(/dark/);
+    await expect(page.locator("html")).toHaveAttribute("data-theme", "light");
 
     // Toggle back to dark
     await themeToggle.click();
     await expect(page.locator("html")).toHaveClass(/dark/);
+    await expect(page.locator("html")).toHaveAttribute("data-theme", "dark");
   });
 
   test("theme persists from landing page to docs", async ({ page }) => {

--- a/apps/docs/tests/playwright/theme-switching.spec.ts
+++ b/apps/docs/tests/playwright/theme-switching.spec.ts
@@ -1,4 +1,85 @@
-import { test, expect } from "@playwright/test";
+import { test, expect, type Page } from "@playwright/test";
+
+type Theme = "dark" | "light";
+type StoredThemePreference = Theme | "" | null;
+
+type ThemeBootstrapEvent = {
+  readonly token: string;
+  readonly force: boolean | undefined;
+  readonly bodyExists: boolean;
+  readonly readyState: DocumentReadyState;
+};
+
+declare global {
+  interface Window {
+    __themeBootstrapEvents?: ThemeBootstrapEvent[];
+  }
+}
+
+type ThemeBootstrapProbeOptions = {
+  readonly page: Page;
+  readonly storedTheme: StoredThemePreference;
+  readonly systemTheme: Theme;
+};
+
+type ThemeBootstrapProbeInit = {
+  readonly storedTheme: StoredThemePreference;
+  readonly systemTheme: Theme;
+};
+
+const findFirstRenderBlockingStyleIndex = (html: string): number =>
+  html.search(/<link[^>]+rel="stylesheet"|<style\b/);
+
+const installThemeBootstrapProbe = async ({
+  page,
+  storedTheme,
+  systemTheme,
+}: ThemeBootstrapProbeOptions): Promise<void> => {
+  await page.addInitScript((options: ThemeBootstrapProbeInit) => {
+    const { storedTheme: initialStoredTheme, systemTheme: initialSystemTheme } =
+      options;
+
+    if (initialStoredTheme === null) {
+      localStorage.removeItem("starlight-theme");
+    } else {
+      localStorage.setItem("starlight-theme", initialStoredTheme);
+    }
+
+    const originalMatchMedia = window.matchMedia.bind(window);
+    window.matchMedia = (query: string): MediaQueryList => {
+      if (query === "(prefers-color-scheme: light)") {
+        return {
+          matches: initialSystemTheme === "light",
+          media: query,
+          onchange: null,
+          addListener: () => undefined,
+          removeListener: () => undefined,
+          addEventListener: () => undefined,
+          removeEventListener: () => undefined,
+          dispatchEvent: () => true,
+        };
+      }
+
+      return originalMatchMedia(query);
+    };
+
+    const originalToggle = DOMTokenList.prototype.toggle;
+    DOMTokenList.prototype.toggle = function toggleDarkClass(token, force) {
+      if (this === document.documentElement?.classList && token === "dark") {
+        const events = window.__themeBootstrapEvents ?? [];
+        events.push({
+          token,
+          force,
+          bodyExists: Boolean(document.body),
+          readyState: document.readyState,
+        });
+        window.__themeBootstrapEvents = events;
+      }
+
+      return originalToggle.call(this, token, force);
+    };
+  }, { storedTheme, systemTheme });
+};
 
 /**
  * Theme Switching Tests
@@ -11,6 +92,141 @@ import { test, expect } from "@playwright/test";
  */
 
 test.describe("Theme Switching", () => {
+  test("landing page bootstraps theme before body renders without hard-coded dark mode", async ({
+    request,
+  }) => {
+    const response = await request.get("/");
+    expect(response.ok()).toBe(true);
+
+    const html = await response.text();
+    const themeBootstrapIndex = html.indexOf("data-theme-bootstrap");
+    const criticalStyleIndex = html.indexOf("data-theme-critical");
+    const bodyIndex = html.indexOf("<body");
+    const firstStyleIndex = findFirstRenderBlockingStyleIndex(html);
+
+    expect(html).not.toMatch(/<html[^>]*class="[^"]*\bdark\b[^"]*"/);
+    expect(themeBootstrapIndex).toBeGreaterThan(-1);
+    expect(criticalStyleIndex).toBeGreaterThan(themeBootstrapIndex);
+    expect(html.slice(firstStyleIndex, firstStyleIndex + 120)).toContain(
+      "data-theme-critical",
+    );
+    expect(firstStyleIndex).toBeGreaterThan(themeBootstrapIndex);
+    expect(bodyIndex).toBeGreaterThan(themeBootstrapIndex);
+  });
+
+  test("docs pages bootstrap theme before render-blocking styles", async ({
+    request,
+  }) => {
+    const response = await request.get("/getting-started/quick-start/");
+    expect(response.ok()).toBe(true);
+
+    const html = await response.text();
+    const themeBootstrapIndex = html.indexOf("data-starlight-theme-bootstrap");
+    const criticalStyleIndex = html.indexOf("data-theme-critical");
+    const bodyIndex = html.indexOf("<body");
+    const firstStyleIndex = findFirstRenderBlockingStyleIndex(html);
+
+    expect(themeBootstrapIndex).toBeGreaterThan(-1);
+    expect(criticalStyleIndex).toBeGreaterThan(themeBootstrapIndex);
+    expect(html.slice(firstStyleIndex, firstStyleIndex + 120)).toContain(
+      "data-theme-critical",
+    );
+    expect(firstStyleIndex).toBeGreaterThan(themeBootstrapIndex);
+    expect(bodyIndex).toBeGreaterThan(themeBootstrapIndex);
+  });
+
+  test("landing page applies stored dark theme before body renders", async ({
+    page,
+  }) => {
+    await installThemeBootstrapProbe({
+      page,
+      storedTheme: "dark",
+      systemTheme: "light",
+    });
+
+    await page.goto("/");
+
+    const events = await page.evaluate(
+      () => window.__themeBootstrapEvents ?? [],
+    );
+    expect(events).toContainEqual({
+      token: "dark",
+      force: true,
+      bodyExists: false,
+      readyState: "loading",
+    });
+    await expect(page.locator("html")).toHaveClass(/dark/);
+  });
+
+  test("landing page applies stored light theme before body renders", async ({
+    page,
+  }) => {
+    await installThemeBootstrapProbe({
+      page,
+      storedTheme: "light",
+      systemTheme: "dark",
+    });
+
+    await page.goto("/");
+
+    const events = await page.evaluate(
+      () => window.__themeBootstrapEvents ?? [],
+    );
+    expect(events).toContainEqual({
+      token: "dark",
+      force: false,
+      bodyExists: false,
+      readyState: "loading",
+    });
+    await expect(page.locator("html")).not.toHaveClass(/dark/);
+  });
+
+  test("landing page applies auto system dark theme before body renders", async ({
+    page,
+  }) => {
+    await installThemeBootstrapProbe({
+      page,
+      storedTheme: "",
+      systemTheme: "dark",
+    });
+
+    await page.goto("/");
+
+    const events = await page.evaluate(
+      () => window.__themeBootstrapEvents ?? [],
+    );
+    expect(events).toContainEqual({
+      token: "dark",
+      force: true,
+      bodyExists: false,
+      readyState: "loading",
+    });
+    await expect(page.locator("html")).toHaveClass(/dark/);
+  });
+
+  test("landing page applies missing preference system light theme before body renders", async ({
+    page,
+  }) => {
+    await installThemeBootstrapProbe({
+      page,
+      storedTheme: null,
+      systemTheme: "light",
+    });
+
+    await page.goto("/");
+
+    const events = await page.evaluate(
+      () => window.__themeBootstrapEvents ?? [],
+    );
+    expect(events).toContainEqual({
+      token: "dark",
+      force: false,
+      bodyExists: false,
+      readyState: "loading",
+    });
+    await expect(page.locator("html")).not.toHaveClass(/dark/);
+  });
+
   test("theme toggle switches between dark and light", async ({ page }) => {
     // Set dark theme explicitly before navigation
     await page.addInitScript(() => {


### PR DESCRIPTION
## Summary
- Prevent the landing page from briefly painting dark when the stored/system preference resolves to light.
- Add a critical inline theme style after the early theme bootstrap so landing page colors are correct before the first stylesheet can render.
- Add the same early bootstrap and critical style to Starlight docs pages, which were still SSRing `data-theme="dark"` before loading light-mode state.
- Add Playwright regression coverage for landing and docs page bootstrap order plus the stored/system landing-page starting points.
- Tighten the landing release badge contrast in light mode, which the corrected light-mode load exposed to axe.

## TDD Evidence
- RED: added a Playwright regression that failed when docs pages had no pre-stylesheet Starlight theme bootstrap.
- GREEN: added the minimal Starlight head bootstrap and critical theme style to satisfy the regression.

## Test Evidence
- `pnpm --filter @scenarist/docs pw theme-switching.spec.ts --project=chromium`: 10 passed
- `pnpm --filter @scenarist/docs test:a11y`: 25 passed
- `pnpm --filter @scenarist/docs build`: passed
- `pnpm --filter @scenarist/docs typecheck`: passed with 0 errors and 1 existing Astro hint
