### PR TITLE
fix(security): clarify regex trust boundary types

### DIFF
--- a/.changeset/quiet-regex-trust-types.md
+++ b/.changeset/quiet-regex-trust-types.md
@@ -1,0 +1,5 @@
+---
+"@scenarist/core": patch
+---
+
+Clarify internal regex matching trust-boundary types.

--- a/internal/core/src/domain/regex-matching.ts
+++ b/internal/core/src/domain/regex-matching.ts
@@ -3,7 +3,12 @@ import {
   type SerializedRegex,
 } from "../schemas/match-criteria.js";
 
-const testRegex = (value: string, pattern: SerializedRegex): boolean => {
+type RegexPatternInput = {
+  readonly source: string;
+  readonly flags?: string;
+};
+
+const testRegex = (value: string, pattern: RegexPatternInput): boolean => {
   try {
     // eslint-disable-next-line security/detect-non-literal-regexp -- Serialized patterns are schema-validated and native RegExp inputs are trusted code.
     const regex = new RegExp(pattern.source, pattern.flags); // nosemgrep: javascript.lang.security.audit.detect-non-literal-regexp.detect-non-literal-regexp
@@ -49,7 +54,7 @@ export const matchesRegex = (
  * **Security:**
  * - Bypasses serialized regex validation intentionally for native RegExp scenario criteria
  * - Do not use with patterns derived from serialized data or user input
- * - Clones the RegExp before testing to avoid mutating caller-owned lastIndex state
+ * - Reconstructs from source and flags before testing to avoid mutating caller-owned lastIndex state
  *
  * @param value - String to test against pattern
  * @param pattern - Native RegExp from trusted code

--- a/internal/core/tests/regex-matching.test.ts
+++ b/internal/core/tests/regex-matching.test.ts
@@ -55,7 +55,7 @@ describe("matchesRegex", () => {
     expect(result).toBe(false);
   });
 
-  it("should return false when the RegExp constructor rejects duplicate flags", () => {
+  it("should return false when duplicate flags pass schema but the RegExp constructor rejects them", () => {
     const result = matchesRegex("test", { source: "test", flags: "ii" });
     expect(result).toBe(false);
   });


### PR DESCRIPTION
## Summary
- follow up PR #515 review feedback by using a narrower internal pattern type for shared regex construction
- clarify the native RegExp matching JSDoc around source/flags reconstruction and lastIndex safety
- rename the duplicate-flags test to identify the constructor-level failure path
- add a patch changeset for @scenarist/core

## Validation
- PATH=/Users/paulhammond/.nvm/versions/node/v22.21.1/bin:/Users/paulhammond/.codex/tmp/arg0/codex-arg06o7Qoj:/Users/paulhammond/pyenv/bin:/Users/paulhammond/Library/pnpm:/opt/homebrew/bin:/opt/homebrew/sbin:/Users/paulhammond/.nvm/versions/node/v24.15.0/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:/Library/Developer/CommandLineTools/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/opt/pmk/env/global/bin:/Library/Apple/usr/bin:/Library/TeX/texbin:/Users/paulhammond/.cargo/bin:/Users/paulhammond/.orbstack/bin:/Users/paulhammond/.local/bin:/opt/homebrew/opt/fzf/bin:/Applications/Codex.app/Contents/Resources pnpm test regex-matching.test.ts url-matching.test.ts (35 tests passed)
- PATH=/Users/paulhammond/.nvm/versions/node/v22.21.1/bin:/Users/paulhammond/.codex/tmp/arg0/codex-arg06o7Qoj:/Users/paulhammond/pyenv/bin:/Users/paulhammond/Library/pnpm:/opt/homebrew/bin:/opt/homebrew/sbin:/Users/paulhammond/.nvm/versions/node/v24.15.0/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:/Library/Developer/CommandLineTools/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/opt/pmk/env/global/bin:/Library/Apple/usr/bin:/Library/TeX/texbin:/Users/paulhammond/.cargo/bin:/Users/paulhammond/.orbstack/bin:/Users/paulhammond/.local/bin:/opt/homebrew/opt/fzf/bin:/Applications/Codex.app/Contents/Resources pnpm exec vitest run --coverage in internal/core (571 tests passed, 100% statements/branches/functions/lines)
- PATH=/Users/paulhammond/.nvm/versions/node/v22.21.1/bin:/Users/paulhammond/.codex/tmp/arg0/codex-arg06o7Qoj:/Users/paulhammond/pyenv/bin:/Users/paulhammond/Library/pnpm:/opt/homebrew/bin:/opt/homebrew/sbin:/Users/paulhammond/.nvm/versions/node/v24.15.0/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:/Library/Developer/CommandLineTools/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/opt/pmk/env/global/bin:/Library/Apple/usr/bin:/Library/TeX/texbin:/Users/paulhammond/.cargo/bin:/Users/paulhammond/.orbstack/bin:/Users/paulhammond/.local/bin:/opt/homebrew/opt/fzf/bin:/Applications/Codex.app/Contents/Resources pnpm typecheck in internal/core
- PATH=/Users/paulhammond/.nvm/versions/node/v22.21.1/bin:/Users/paulhammond/.codex/tmp/arg0/codex-arg06o7Qoj:/Users/paulhammond/pyenv/bin:/Users/paulhammond/Library/pnpm:/opt/homebrew/bin:/opt/homebrew/sbin:/Users/paulhammond/.nvm/versions/node/v24.15.0/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:/Library/Developer/CommandLineTools/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/opt/pmk/env/global/bin:/Library/Apple/usr/bin:/Library/TeX/texbin:/Users/paulhammond/.cargo/bin:/Users/paulhammond/.orbstack/bin:/Users/paulhammond/.local/bin:/opt/homebrew/opt/fzf/bin:/Applications/Codex.app/Contents/Resources pnpm lint in internal/core (0 errors, existing warning-level findings remain)
- focused Semgrep auto scan on touched files (0 findings)

Follow-up to #515.